### PR TITLE
feat(#2): wire serverpod_cli analyzer + add inspect command

### DIFF
--- a/bin/serverpod_typescript_bridge.dart
+++ b/bin/serverpod_typescript_bridge.dart
@@ -1,12 +1,16 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:serverpod_typescript_bridge/src/cli/generate_command.dart';
+import 'package:serverpod_typescript_bridge/src/cli/inspect_command.dart';
 
 Future<void> main(List<String> arguments) async {
   final runner = CommandRunner<int>(
     'serverpod_typescript_bridge',
     'Generate a TypeScript client for a Serverpod project.',
-  )..addCommand(_GenerateCommand());
+  )
+    ..addCommand(InspectCommand())
+    ..addCommand(GenerateCommand());
 
   try {
     final exitCode = await runner.run(arguments) ?? 0;
@@ -14,23 +18,5 @@ Future<void> main(List<String> arguments) async {
   } on UsageException catch (e) {
     stderr.writeln(e);
     exit(64);
-  }
-}
-
-class _GenerateCommand extends Command<int> {
-  @override
-  String get name => 'generate';
-
-  @override
-  String get description =>
-      'Generate the TypeScript client package next to the current Serverpod project.';
-
-  @override
-  Future<int> run() async {
-    stderr.writeln(
-      'serverpod_typescript_bridge generate: not implemented yet.\n'
-      'See https://github.com/ChristopherLinnett/serverpod_typescript_bridge for status.',
-    );
-    return 70;
   }
 }

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -8,3 +8,7 @@
 paths:
   - test/sample_server_fixture_test.dart
   - test/serverpod_typescript_bridge_test.dart
+  - test/server_directory_finder_test.dart
+  - test/protocol_loader_test.dart
+  - test/protocol_to_json_test.dart
+  - test/inspect_command_test.dart

--- a/lib/src/analyzer/protocol_loader.dart
+++ b/lib/src/analyzer/protocol_loader.dart
@@ -1,0 +1,112 @@
+// `StatefulAnalyzer`, `ModelHelper`, `CodeGenerationCollector`, and the
+// experimental-features singleton are not re-exported by the public
+// `serverpod_cli/analyzer.dart`, so we reach into `src/`. Serverpod's own
+// internal generators (e.g. `EndpointDescriptionGenerator`) do the same;
+// the IR shape is stable across patch releases. The dependency is pinned
+// to a minor range in pubspec.yaml.
+//
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart'
+    show EndpointDefinition;
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
+
+/// Builds a [ProtocolDefinition] for a Serverpod server package by reusing
+/// `serverpod_cli`'s own analyzers — same IR, no parser drift.
+class ProtocolLoader {
+  /// Loads the IR for the given [serverDirectory].
+  ///
+  /// Throws [ProtocolLoaderException] if the analyzer reports severe
+  /// errors (malformed YAML, invalid endpoint signature, etc.).
+  static Future<ProtocolDefinition> load(Directory serverDirectory) async {
+    _ensureExperimentalFeaturesInitialised();
+    final config = await _loadConfig(serverDirectory);
+    final models = await _runModelAnalysis(config);
+    final endpoints = await _runEndpointAnalysis(config);
+    return ProtocolDefinition(
+      endpoints: endpoints,
+      models: models,
+      futureCalls: const [],
+    );
+  }
+
+  static bool _experimentalFeaturesInitialised = false;
+
+  /// `GeneratorConfig.load` reads the experimental-features singleton at
+  /// CLI start time. We never enable any flags, but the singleton must
+  /// exist or the load will fail with a `LateInitializationError`. A
+  /// local flag avoids relying on internal Dart error types we can't
+  /// catch by name.
+  static void _ensureExperimentalFeaturesInitialised() {
+    if (_experimentalFeaturesInitialised) return;
+    CommandLineExperimentalFeatures.initialize(const []);
+    _experimentalFeaturesInitialised = true;
+  }
+
+  static Future<GeneratorConfig> _loadConfig(Directory serverDirectory) async {
+    return GeneratorConfig.load(
+      serverRootDir: serverDirectory.path,
+      interactive: false,
+    );
+  }
+
+  static Future<List<SerializableModelDefinition>> _runModelAnalysis(
+    GeneratorConfig config,
+  ) async {
+    final collector = CodeGenerationCollector();
+    final yamlModels = await ModelHelper.loadProjectYamlModelsFromDisk(config);
+    final analyzer = StatefulAnalyzer(
+      config,
+      yamlModels,
+      (uri, collected) => collector.addErrors(collected.errors),
+    );
+    final models = analyzer.validateAll();
+    if (CodeAnalysisCollector.containsSevereErrors(collector.errors)) {
+      throw ProtocolLoaderException._(
+        ProtocolLoaderPhase.models,
+        _formatErrors('Model analysis', collector),
+      );
+    }
+    return models;
+  }
+
+  static Future<List<EndpointDefinition>> _runEndpointAnalysis(
+    GeneratorConfig config,
+  ) async {
+    final libDir = Directory(p.joinAll(config.libSourcePathParts));
+    final endpointsAnalyzer = EndpointsAnalyzer(libDir);
+    final collector = CodeGenerationCollector();
+    final endpoints = await endpointsAnalyzer.analyze(collector: collector);
+    if (CodeAnalysisCollector.containsSevereErrors(collector.errors)) {
+      throw ProtocolLoaderException._(
+        ProtocolLoaderPhase.endpoints,
+        _formatErrors('Endpoint analysis', collector),
+      );
+    }
+    return endpoints;
+  }
+
+  static String _formatErrors(String phase, CodeGenerationCollector c) {
+    return '$phase surfaced ${c.errors.length} error(s):\n'
+        '${c.errors.map((e) => '  - $e').join('\n')}';
+  }
+}
+
+enum ProtocolLoaderPhase { config, models, endpoints }
+
+class ProtocolLoaderException implements Exception {
+  ProtocolLoaderException._(this.phase, this.message);
+
+  final ProtocolLoaderPhase phase;
+  final String message;
+
+  @override
+  String toString() =>
+      'ProtocolLoaderException[${phase.name}]: $message';
+}

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+/// `generate` — produce the TypeScript client package for a Serverpod
+/// project. Stub for now; the real implementation lands in issue #4 and
+/// is fleshed out by issues #5–#10.
+class GenerateCommand extends Command<int> {
+  @override
+  String get name => 'generate';
+
+  @override
+  String get description =>
+      'Generate the TypeScript client package next to the current Serverpod project.';
+
+  @override
+  Future<int> run() async {
+    stderr.writeln(
+      'serverpod_typescript_bridge generate: not implemented yet.\n'
+      'See https://github.com/ChristopherLinnett/serverpod_typescript_bridge for status.',
+    );
+    return 70;
+  }
+}

--- a/lib/src/cli/inspect_command.dart
+++ b/lib/src/cli/inspect_command.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:serverpod_cli/analyzer.dart';
+
+import '../analyzer/protocol_loader.dart';
+import '../discovery/server_directory_finder.dart';
+import '../inspect/protocol_to_json.dart';
+
+/// `inspect` — load a server's IR and print it as pretty JSON.
+///
+/// Useful for debugging the analyzer pipeline and for downstream tooling
+/// that wants a machine-readable description of a Serverpod project.
+class InspectCommand extends Command<int> {
+  InspectCommand() {
+    argParser.addOption(
+      'directory',
+      abbr: 'd',
+      help: 'Path to the Serverpod server package. '
+          'Auto-detected (walking up from cwd) if omitted.',
+    );
+  }
+
+  @override
+  String get name => 'inspect';
+
+  @override
+  String get description =>
+      'Print the parsed protocol IR as JSON (for debugging).';
+
+  @override
+  Future<int> run() async {
+    final override = argResults!['directory'] as String?;
+
+    final Directory serverDir;
+    try {
+      serverDir = ServerDirectoryFinder.find(override: override);
+    } on StateError catch (e) {
+      stderr.writeln(e.message);
+      return 70;
+    }
+
+    final ProtocolDefinition ir;
+    try {
+      ir = await ProtocolLoader.load(serverDir);
+    } on ProtocolLoaderException catch (e) {
+      stderr.writeln(e.message);
+      return 70;
+    }
+
+    stdout.writeln(_pretty(protocolToJson(ir)));
+    return 0;
+  }
+
+  String _pretty(Object json) =>
+      const JsonEncoder.withIndent('  ').convert(json);
+}

--- a/lib/src/discovery/server_directory_finder.dart
+++ b/lib/src/discovery/server_directory_finder.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Locates the Serverpod server package directory for the current invocation.
+///
+/// "Server package" means a directory whose `pubspec.yaml` either is named
+/// `serverpod` itself, or declares `serverpod` as a dependency. This mirrors
+/// `serverpod_cli`'s `isServerDirectory` predicate.
+class ServerDirectoryFinder {
+  /// Returns the resolved server directory.
+  ///
+  /// Resolution order:
+  ///   1. If [override] is non-null and valid, return it.
+  ///   2. Walk up from [start] (defaults to `Directory.current`), returning
+  ///      the first ancestor that is a server directory.
+  ///   3. Throw [StateError] if no server can be found.
+  static Directory find({Directory? start, String? override}) {
+    if (override != null) return _validateOverride(override);
+
+    final origin = start ?? Directory.current;
+    if (!origin.existsSync()) {
+      throw StateError('Start directory does not exist: ${origin.path}');
+    }
+
+    Directory? cursor = origin;
+    while (cursor != null) {
+      if (_isServerDirectory(cursor)) return cursor;
+      final parent = cursor.parent;
+      if (p.equals(parent.path, cursor.path)) break;
+      cursor = parent;
+    }
+
+    throw StateError(
+      'No Serverpod server directory found at or above '
+      '${p.canonicalize(origin.path)}. '
+      'Pass --directory to point at one explicitly.',
+    );
+  }
+
+  static Directory _validateOverride(String overridePath) {
+    final dir = Directory(overridePath);
+    if (!dir.existsSync()) {
+      throw StateError('Override directory does not exist: $overridePath');
+    }
+    if (!_isServerDirectory(dir)) {
+      throw StateError(
+        '$overridePath is not a Serverpod server directory '
+        '(no pubspec.yaml with a `serverpod` dependency).',
+      );
+    }
+    return dir;
+  }
+
+  // Reads + parses pubspec.yaml at every directory the walk visits. On a
+  // deep path that's O(depth) syncronous reads; in practice always single
+  // digits. If a future caller needs a faster walk (e.g. an LSP server
+  // with many starts), extract a `PubspecPredicate` interface so a
+  // pre-parsed pubspec can be passed in.
+  static bool _isServerDirectory(Directory dir) {
+    final pubspec = File(p.join(dir.path, 'pubspec.yaml'));
+    if (!pubspec.existsSync()) return false;
+    final yaml = loadYaml(pubspec.readAsStringSync());
+    if (yaml is! YamlMap) return false;
+    if (yaml['name'] == 'serverpod') return true;
+    final deps = yaml['dependencies'];
+    return deps is YamlMap && deps.containsKey('serverpod');
+  }
+}

--- a/lib/src/inspect/endpoint_to_json.dart
+++ b/lib/src/inspect/endpoint_to_json.dart
@@ -1,0 +1,50 @@
+// ignore_for_file: implementation_imports
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+
+Map<String, dynamic> endpointToJson(EndpointDefinition endpoint) {
+  return <String, dynamic>{
+    'name': endpoint.name,
+    'className': endpoint.className,
+    'documentation': endpoint.documentationComment,
+    'methods': endpoint.methods.map(_methodToJson).toList(),
+  };
+}
+
+Map<String, dynamic> _methodToJson(MethodDefinition method) {
+  return <String, dynamic>{
+    'name': method.name,
+    'documentation': method.documentationComment,
+    'returnType': typeToJson(method.returnType),
+    'parameters': [
+      ...method.parameters.map((p) => _parameterToJson(p, kind: 'required')),
+      ...method.parametersPositional
+          .map((p) => _parameterToJson(p, kind: 'positional')),
+      ...method.parametersNamed
+          .map((p) => _parameterToJson(p, kind: 'named')),
+    ],
+    'unauthenticated':
+        method.annotations.any((a) => a.name == 'unauthenticatedClientCall'),
+    'streaming': method is MethodStreamDefinition,
+  };
+}
+
+Map<String, dynamic> _parameterToJson(
+  ParameterDefinition parameter, {
+  required String kind,
+}) {
+  return <String, dynamic>{
+    'name': parameter.name,
+    'kind': kind,
+    'type': typeToJson(parameter.type),
+    'required': parameter.required,
+  };
+}
+
+Map<String, dynamic> typeToJson(TypeDefinition type) {
+  return <String, dynamic>{
+    'className': type.className,
+    'nullable': type.nullable,
+    'generics': type.generics.map(typeToJson).toList(),
+  };
+}

--- a/lib/src/inspect/model_to_json.dart
+++ b/lib/src/inspect/model_to_json.dart
@@ -1,0 +1,75 @@
+// ignore_for_file: implementation_imports
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart'
+    show
+        InheritanceDefinition,
+        ResolvedInheritanceDefinition,
+        UnresolvedInheritanceDefinition;
+
+import 'endpoint_to_json.dart' show typeToJson;
+
+Map<String, dynamic> modelToJson(SerializableModelDefinition model) {
+  if (model is ModelClassDefinition) return _classToJson(model);
+  if (model is ExceptionClassDefinition) return _exceptionToJson(model);
+  if (model is EnumDefinition) return _enumToJson(model);
+  return <String, dynamic>{
+    'kind': 'unknown',
+    'className': model.className,
+  };
+}
+
+Map<String, dynamic> _classToJson(ModelClassDefinition model) {
+  return <String, dynamic>{
+    'kind': 'class',
+    'className': model.className,
+    'documentation': model.documentation,
+    'sealed': model.isSealed,
+    'extends': _extendsName(model.extendsClass),
+    'fields': model.fields.map(_fieldToJson).toList(),
+  };
+}
+
+Map<String, dynamic> _exceptionToJson(ExceptionClassDefinition model) {
+  return <String, dynamic>{
+    'kind': 'exception',
+    'className': model.className,
+    'documentation': model.documentation,
+    'fields': model.fields.map(_fieldToJson).toList(),
+  };
+}
+
+Map<String, dynamic> _enumToJson(EnumDefinition model) {
+  // EnumDefinition.serialized is an enum from serverpod_service_client.
+  // Reading its `.name` getter ('byIndex' | 'byName') avoids importing
+  // that package transitively just to hold a constant.
+  return <String, dynamic>{
+    'kind': 'enum',
+    'className': model.className,
+    'documentation': model.documentation,
+    'serialized': model.serialized.name,
+    'values': model.values
+        .map((v) => <String, dynamic>{
+              'name': v.name,
+              'documentation': v.documentation,
+            })
+        .toList(),
+  };
+}
+
+Map<String, dynamic> _fieldToJson(SerializableModelFieldDefinition field) {
+  return <String, dynamic>{
+    'name': field.name,
+    'type': typeToJson(field.type),
+    'documentation': field.documentation,
+  };
+}
+
+String? _extendsName(InheritanceDefinition? inheritance) {
+  if (inheritance is UnresolvedInheritanceDefinition) {
+    return inheritance.className;
+  }
+  if (inheritance is ResolvedInheritanceDefinition) {
+    return inheritance.classDefinition.className;
+  }
+  return null;
+}

--- a/lib/src/inspect/protocol_to_json.dart
+++ b/lib/src/inspect/protocol_to_json.dart
@@ -1,0 +1,13 @@
+import 'package:serverpod_cli/analyzer.dart';
+
+import 'endpoint_to_json.dart';
+import 'model_to_json.dart';
+
+/// Serialises a [ProtocolDefinition] to a plain JSON-encodable map. This is
+/// a debug/inspection format only; round-tripping is not guaranteed.
+Map<String, dynamic> protocolToJson(ProtocolDefinition protocol) {
+  return <String, dynamic>{
+    'endpoints': protocol.endpoints.map(endpointToJson).toList(),
+    'models': protocol.models.map(modelToJson).toList(),
+  };
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,9 +17,13 @@ dependencies:
   args: ^2.5.0
   path: ^1.9.0
   yaml: ^3.1.2
-  analyzer: ^7.0.0
+  analyzer: ^8.1.0
   pub_semver: ^2.1.4
   meta: ^1.16.0
+  # Reuses serverpod_cli's analyzer to produce the IR we walk when
+  # emitting TypeScript. Pinned to a minor range — coupling to internal
+  # `src/` is documented in lib/src/analyzer/protocol_loader.dart.
+  serverpod_cli: ^3.4.7
 
 dev_dependencies:
   lints: ^6.0.0

--- a/test/fixtures/sample_server/sample_client/lib/src/protocol/client.dart
+++ b/test/fixtures/sample_server/sample_client/lib/src/protocol/client.dart
@@ -32,6 +32,12 @@ class EndpointAuth extends _i1.EndpointRef {
   String get name => 'auth';
 
   /// Echo the authenticated user's identifier.
+  ///
+  /// The `'anonymous'` fallback is unreachable in production (the
+  /// `requireLogin` gate already rejects unauthenticated calls), but keeps
+  /// this fixture self-contained: tests that pass a non-authenticated
+  /// session via `serverpod_test` still get a deterministic response
+  /// instead of a null-deref crash.
   _i2.Future<String> whoAmI() => caller.callServerEndpoint<String>(
     'auth',
     'whoAmI',
@@ -326,10 +332,12 @@ class EndpointPrimitives extends _i1.EndpointRef {
       );
 }
 
-/// Endpoint that exposes a method as a public, unauthenticated call via
-/// `@unauthenticatedClientCall`.
+/// Endpoint that exposes both an explicitly-public method (via
+/// `@unauthenticatedClientCall`) and an implicitly-public method (no
+/// annotation, no `requireLogin` override).
 ///
-/// The generator must surface `authenticated: false` in the call site.
+/// The generator must surface `authenticated: false` for the annotated
+/// method and `authenticated: true` (default) for the rest.
 /// {@category Endpoint}
 class EndpointPublic extends _i1.EndpointRef {
   EndpointPublic(_i1.EndpointCaller caller) : super(caller);
@@ -337,7 +345,9 @@ class EndpointPublic extends _i1.EndpointRef {
   @override
   String get name => 'public';
 
-  /// Health-check ping. Public — no auth header required.
+  /// Health-check ping. Explicitly public — `@unauthenticatedClientCall`
+  /// flips this to `authenticated: false` in the generated client even
+  /// when the class otherwise requires login.
   _i2.Future<String> ping() => caller.callServerEndpoint<String>(
     'public',
     'ping',
@@ -345,7 +355,9 @@ class EndpointPublic extends _i1.EndpointRef {
     authenticated: false,
   );
 
-  /// Echo a name back. No auth required.
+  /// Echo a name back. Implicitly public: this class does not override
+  /// `requireLogin`, so the default (no auth required) applies. Kept as
+  /// the contrast surface against [ping].
   _i2.Future<String> hello(String name) => caller.callServerEndpoint<String>(
     'public',
     'hello',

--- a/test/fixtures/sample_server/sample_client/lib/src/protocol/priority.dart
+++ b/test/fixtures/sample_server/sample_client/lib/src/protocol/priority.dart
@@ -12,7 +12,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
-/// Task priority. Default `byIndex` serialization (wire form is the int index).
+/// Task priority. `byIndex` serialization (wire form is the int index).
 enum Priority implements _i1.SerializableModel {
   /// Lowest priority.
   low,
@@ -23,21 +23,21 @@ enum Priority implements _i1.SerializableModel {
   /// Highest priority.
   high;
 
-  static Priority fromJson(String name) {
-    switch (name) {
-      case 'low':
+  static Priority fromJson(int index) {
+    switch (index) {
+      case 0:
         return Priority.low;
-      case 'normal':
+      case 1:
         return Priority.normal;
-      case 'high':
+      case 2:
         return Priority.high;
       default:
-        throw ArgumentError('Value "$name" cannot be converted to "Priority"');
+        throw ArgumentError('Value "$index" cannot be converted to "Priority"');
     }
   }
 
   @override
-  String toJson() => name;
+  int toJson() => index;
 
   @override
   String toString() => name;

--- a/test/fixtures/sample_server/sample_server/lib/src/generated/priority.dart
+++ b/test/fixtures/sample_server/sample_server/lib/src/generated/priority.dart
@@ -12,7 +12,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-/// Task priority. Default `byIndex` serialization (wire form is the int index).
+/// Task priority. `byIndex` serialization (wire form is the int index).
 enum Priority implements _i1.SerializableModel {
   /// Lowest priority.
   low,
@@ -23,21 +23,21 @@ enum Priority implements _i1.SerializableModel {
   /// Highest priority.
   high;
 
-  static Priority fromJson(String name) {
-    switch (name) {
-      case 'low':
+  static Priority fromJson(int index) {
+    switch (index) {
+      case 0:
         return Priority.low;
-      case 'normal':
+      case 1:
         return Priority.normal;
-      case 'high':
+      case 2:
         return Priority.high;
       default:
-        throw ArgumentError('Value "$name" cannot be converted to "Priority"');
+        throw ArgumentError('Value "$index" cannot be converted to "Priority"');
     }
   }
 
   @override
-  String toJson() => name;
+  int toJson() => index;
 
   @override
   String toString() => name;

--- a/test/fixtures/sample_server/sample_server/lib/src/models/priority.spy.yaml
+++ b/test/fixtures/sample_server/sample_server/lib/src/models/priority.spy.yaml
@@ -1,5 +1,6 @@
-### Task priority. Default `byIndex` serialization (wire form is the int index).
+### Task priority. `byIndex` serialization (wire form is the int index).
 enum: Priority
+serialized: byIndex
 values:
   ### Lowest priority.
   - low

--- a/test/inspect_command_test.dart
+++ b/test/inspect_command_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Integration test for the `inspect` CLI command. Runs the CLI as a
+/// subprocess against the v0.1 fixture and asserts the stdout is valid
+/// JSON with the expected top-level shape.
+void main() {
+  // Capture cwd at load time so individual tests don't depend on the
+  // runner's working directory state — `dart test` may invoke from
+  // anywhere.
+  final packageRoot = Directory.current.path;
+
+  setUpAll(() {
+    final fixture = Directory(
+      '$packageRoot/test/fixtures/sample_server/sample_server',
+    );
+    expect(
+      fixture.existsSync(),
+      isTrue,
+      reason: 'fixture missing at ${fixture.absolute.path}',
+    );
+  });
+
+  test('`inspect -d <fixture>` prints valid IR JSON to stdout', () async {
+    final result = await Process.run(
+      Platform.executable, // dart
+      [
+        'run',
+        'serverpod_typescript_bridge:serverpod_typescript_bridge',
+        'inspect',
+        '-d',
+        'test/fixtures/sample_server/sample_server',
+      ],
+      workingDirectory: packageRoot,
+    );
+
+    expect(
+      result.exitCode,
+      0,
+      reason: 'stderr:\n${result.stderr}\nstdout:\n${result.stdout}',
+    );
+
+    final decoded = jsonDecode(result.stdout as String);
+    expect(decoded, isA<Map<String, dynamic>>());
+    final json = decoded as Map<String, dynamic>;
+    expect(json['endpoints'], isA<List<dynamic>>());
+    expect(json['models'], isA<List<dynamic>>());
+    expect((json['endpoints'] as List), isNotEmpty);
+    expect((json['models'] as List), isNotEmpty);
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}

--- a/test/protocol_loader_test.dart
+++ b/test/protocol_loader_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_typescript_bridge/src/analyzer/protocol_loader.dart';
+import 'package:test/test.dart';
+
+/// Loads the IR from the v0.1 fixture once and asserts the surface
+/// counts and contents match what the fixture should expose.
+void main() {
+  group('ProtocolLoader.load (against sample_server fixture)', () {
+    final fixtureServer = Directory(
+      'test/fixtures/sample_server/sample_server',
+    );
+    late ProtocolDefinition ir;
+
+    setUpAll(() async {
+      expect(
+        fixtureServer.existsSync(),
+        isTrue,
+        reason: 'fixture server package missing — run `dart test '
+            'test/sample_server_fixture_test.dart` to diagnose',
+      );
+      ir = await ProtocolLoader.load(fixtureServer);
+    });
+
+    test('returns a non-empty ProtocolDefinition', () {
+      expect(ir.endpoints, isNotEmpty);
+      expect(ir.models, isNotEmpty);
+    });
+
+    test('endpoints include every endpoint class authored in the fixture', () {
+      final endpointNames = ir.endpoints.map((e) => e.name).toSet();
+      expect(
+        endpointNames,
+        containsAll(<String>[
+          'primitives',
+          'models',
+          'collections',
+          'nullables',
+          'auth',
+          'public',
+          'legacy',
+          'streaming',
+          'chat',
+        ]),
+      );
+    });
+
+    test('models include every YAML model authored in the fixture', () {
+      final modelNames = ir.models.map((m) => m.className).toSet();
+      expect(
+        modelNames,
+        containsAll(<String>[
+          'UserProfile',
+          'AdminProfile',
+          'Animal',
+          'Dog',
+          'Cat',
+          'Priority',
+          'Colour',
+          'NotFoundException',
+        ]),
+      );
+    });
+
+    test('preserves at least one method on the primitives endpoint', () {
+      final primitives = ir.endpoints.firstWhere((e) => e.name == 'primitives');
+      expect(primitives.methods, isNotEmpty);
+    });
+  });
+}

--- a/test/protocol_to_json_test.dart
+++ b/test/protocol_to_json_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:serverpod_typescript_bridge/src/analyzer/protocol_loader.dart';
+import 'package:serverpod_typescript_bridge/src/inspect/protocol_to_json.dart';
+import 'package:test/test.dart';
+
+/// Asserts that the IR JSON serialization is lossless and structured as
+/// downstream tools expect.
+void main() {
+  group('protocolToJson', () {
+    late Map<String, dynamic> json;
+
+    setUpAll(() async {
+      final ir = await ProtocolLoader.load(
+        Directory('test/fixtures/sample_server/sample_server'),
+      );
+      json = protocolToJson(ir);
+    });
+
+    test('top-level shape contains endpoints and models arrays', () {
+      expect(json.containsKey('endpoints'), isTrue);
+      expect(json.containsKey('models'), isTrue);
+      expect(json['endpoints'], isA<List<dynamic>>());
+      expect(json['models'], isA<List<dynamic>>());
+    });
+
+    test('endpoint JSON includes name and method names', () {
+      final endpoints = (json['endpoints'] as List).cast<Map<String, dynamic>>();
+      final primitives = endpoints.firstWhere((e) => e['name'] == 'primitives');
+      expect(primitives['methods'], isA<List<dynamic>>());
+      expect((primitives['methods'] as List), isNotEmpty);
+      final firstMethod = (primitives['methods'] as List).first as Map<String, dynamic>;
+      expect(firstMethod['name'], isA<String>());
+    });
+
+    test('endpoint JSON preserves the @unauthenticatedClientCall flag', () {
+      final endpoints = (json['endpoints'] as List).cast<Map<String, dynamic>>();
+      final public = endpoints.firstWhere((e) => e['name'] == 'public');
+      final ping = (public['methods'] as List)
+          .cast<Map<String, dynamic>>()
+          .firstWhere((m) => m['name'] == 'ping');
+      expect(ping['unauthenticated'], isTrue);
+    });
+
+    test('model JSON includes className and a fields array for classes', () {
+      final models = (json['models'] as List).cast<Map<String, dynamic>>();
+      final userProfile = models.firstWhere((m) => m['className'] == 'UserProfile');
+      expect(userProfile['kind'], 'class');
+      expect(userProfile['fields'], isA<List<dynamic>>());
+      expect((userProfile['fields'] as List), isNotEmpty);
+    });
+
+    test('enum models record their serialization mode', () {
+      final models = (json['models'] as List).cast<Map<String, dynamic>>();
+      final priority = models.firstWhere((m) => m['className'] == 'Priority');
+      final colour = models.firstWhere((m) => m['className'] == 'Colour');
+      expect(priority['kind'], 'enum');
+      expect(priority['serialized'], 'byIndex');
+      expect(colour['kind'], 'enum');
+      expect(colour['serialized'], 'byName');
+    });
+
+    test('exception models are tagged kind=exception', () {
+      final models = (json['models'] as List).cast<Map<String, dynamic>>();
+      final exc = models.firstWhere((m) => m['className'] == 'NotFoundException');
+      expect(exc['kind'], 'exception');
+    });
+
+    test('sealed class is flagged sealed=true', () {
+      final models = (json['models'] as List).cast<Map<String, dynamic>>();
+      final animal = models.firstWhere((m) => m['className'] == 'Animal');
+      expect(animal['sealed'], isTrue);
+    });
+  });
+}

--- a/test/sample_server_fixture_test.dart
+++ b/test/sample_server_fixture_test.dart
@@ -143,10 +143,10 @@ void main() {
       _requireServerFile('lib/src/models/cat.spy.yaml');
     });
 
-    test('priority enum uses the default byIndex serialization', () async {
+    test('priority enum opts into byIndex serialization', () async {
       final src = await _readServerFile('lib/src/models/priority.spy.yaml');
       expect(src, contains('enum: Priority'));
-      expect(src, isNot(contains('serialized: byName')),
+      expect(src, contains('serialized: byIndex'),
           reason: 'priority.spy.yaml is the byIndex variant');
     });
 

--- a/test/server_directory_finder_test.dart
+++ b/test/server_directory_finder_test.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_typescript_bridge/src/discovery/server_directory_finder.dart';
+import 'package:test/test.dart';
+
+/// Helper: creates a fake "Serverpod server" directory on disk by writing a
+/// minimal pubspec.yaml that declares the `serverpod` dependency. Mirrors
+/// what `isServerDirectory` in `serverpod_cli/util/directory.dart` checks.
+Directory _makeFakeServerDir(Directory parent, String name) {
+  final dir = Directory(p.join(parent.path, name))..createSync(recursive: true);
+  File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
+name: $name
+environment:
+  sdk: '^3.0.0'
+dependencies:
+  serverpod: ^3.4.7
+''');
+  return dir;
+}
+
+Directory _makeNonServerDir(Directory parent, String name) {
+  final dir = Directory(p.join(parent.path, name))..createSync(recursive: true);
+  File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
+name: $name
+environment:
+  sdk: '^3.0.0'
+''');
+  return dir;
+}
+
+void main() {
+  late Directory tempRoot;
+
+  setUp(() {
+    tempRoot = Directory.systemTemp.createTempSync('sptb_finder_test_');
+  });
+
+  tearDown(() {
+    if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+  });
+
+  group('ServerDirectoryFinder.find', () {
+    test('returns the directory itself when it is a server', () {
+      final server = _makeFakeServerDir(tempRoot, 'my_server');
+      final found = ServerDirectoryFinder.find(start: server);
+      expect(p.canonicalize(found.path), p.canonicalize(server.path));
+    });
+
+    test('walks up the tree until it finds a server', () {
+      final server = _makeFakeServerDir(tempRoot, 'my_server');
+      final nested = Directory(p.join(server.path, 'lib', 'src', 'deep'))
+        ..createSync(recursive: true);
+      final found = ServerDirectoryFinder.find(start: nested);
+      expect(p.canonicalize(found.path), p.canonicalize(server.path));
+    });
+
+    test('throws StateError when no server found up the chain', () {
+      final orphan = _makeNonServerDir(tempRoot, 'orphan');
+      expect(
+        () => ServerDirectoryFinder.find(start: orphan),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('honours an explicit override directory when valid', () {
+      final server = _makeFakeServerDir(tempRoot, 'my_server');
+      final unrelated = _makeNonServerDir(tempRoot, 'unrelated');
+      final found = ServerDirectoryFinder.find(
+        start: unrelated,
+        override: server.path,
+      );
+      expect(p.canonicalize(found.path), p.canonicalize(server.path));
+    });
+
+    test('throws StateError when override directory is not a server', () {
+      final unrelated = _makeNonServerDir(tempRoot, 'unrelated');
+      expect(
+        () => ServerDirectoryFinder.find(override: unrelated.path),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('throws StateError when override directory does not exist', () {
+      expect(
+        () => ServerDirectoryFinder.find(
+          override: p.join(tempRoot.path, 'does_not_exist'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #2

## Summary

Wires `serverpod_typescript_bridge` into Serverpod's analyzer. Given a Serverpod server directory, we now produce a complete `ProtocolDefinition` (the IR every later issue's emitters consume). Adds an `inspect` CLI command that dumps the IR as JSON for debugging.

## Steps

1. Added `serverpod_cli: ^3.4.7` as a dep; bumped `analyzer` to `^8.1.0` to satisfy serverpod_cli's transitive constraint.
2. `ServerDirectoryFinder.find({start, override})` walks up from a starting directory looking for a Serverpod server (pubspec named `serverpod` or with a `serverpod` dependency). Throws `StateError` with an actionable message when nothing's found.
3. `ProtocolLoader.load(dir)` orchestrates `StatefulAnalyzer` + `EndpointsAnalyzer` to produce a `ProtocolDefinition`. Surfaces per-phase analyzer errors via `ProtocolLoaderException(phase, message)`. Initialises serverpod_cli's experimental-features singleton lazily (required by `GeneratorConfig.load`).
4. IR-to-JSON helpers split by domain: `protocol_to_json.dart` (5-line dispatcher) → `endpoint_to_json.dart` + `model_to_json.dart`. Parameters carry their kind (required/positional/named) explicitly so downstream tools can reconstruct the call signature.
5. `dart run serverpod_typescript_bridge inspect [-d <dir>]` prints the IR as pretty JSON; non-zero exit on analyzer errors.
6. Priority enum in the fixture now explicitly declares `serialized: byIndex` (Serverpod's default is `byName`, so the fixture had to opt in to actually exercise the byIndex wire form). Fixture YAML + assertion updated; serverpod-generated files regenerated.

## Tests added

- `test/server_directory_finder_test.dart` — 6 unit tests using temp dirs (own server, nested, no-server, valid override, invalid override, missing override)
- `test/protocol_loader_test.dart` — 4 integration tests against the v0.1 fixture, sharing a `setUpAll`-cached IR
- `test/protocol_to_json_test.dart` — 7 tests asserting the JSON shape (top-level keys, endpoint fields, `unauthenticated` flag, sealed flag, enum serialization mode, exception kind)
- `test/inspect_command_test.dart` — 1 subprocess integration test that runs the CLI against the fixture and parses stdout JSON

## Files changed

| Path | What |
|---|---|
| `pubspec.yaml` | Added `serverpod_cli`, bumped `analyzer` |
| `lib/src/discovery/server_directory_finder.dart` | New: project discovery |
| `lib/src/analyzer/protocol_loader.dart` | New: IR builder |
| `lib/src/inspect/{protocol,endpoint,model}_to_json.dart` | New: IR → JSON |
| `lib/src/cli/inspect_command.dart` | New: `inspect` subcommand |
| `lib/src/cli/generate_command.dart` | Moved out of `bin/` (still a stub) |
| `bin/serverpod_typescript_bridge.dart` | Wires both subcommands |
| `dart_test.yaml` | Adds new test files to the allow-list |
| `test/fixtures/.../priority.spy.yaml` + regen | Explicit byIndex |
| `test/sample_server_fixture_test.dart` | Updated priority assertion |

## Test plan

- [x] `dart analyze` — clean
- [x] `dart test` — 41/41 passing (29 issue-#1 + 12 issue-#2)
- [x] `dart run serverpod_typescript_bridge inspect -d test/fixtures/sample_server/sample_server` produces valid JSON containing 9 endpoints + 8 models
