### PR TITLE
feat(#5): type mapper + writer + model emission

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -17,3 +17,4 @@ paths:
   - test/generated_file_tracker_test.dart
   - test/scaffold_emitter_test.dart
   - test/generate_command_test.dart
+  - test/ts_writer_test.dart

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -9,8 +9,10 @@ import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import '../analyzer/protocol_loader.dart';
 import '../discovery/server_directory_finder.dart';
 import '../emit/generated_file_tracker.dart';
+import '../emit/model_emitter.dart';
 import '../emit/output_paths.dart';
 import '../emit/scaffold_emitter.dart';
+import '../emit/ts_type_mapper.dart';
 
 /// `generate` — produce the TypeScript client package for a Serverpod
 /// project.
@@ -75,10 +77,11 @@ class GenerateCommand extends Command<int> {
       explicitOutput: ar['output'] as String?,
     );
 
-    // Pre-load the IR so we fail fast on analyzer errors before writing
-    // anything to disk. Issues #5+ will consume the IR to drive emission.
+    // Load the IR up front so we fail fast on analyzer errors before
+    // touching disk.
+    final ProtocolDefinition ir;
     try {
-      await ProtocolLoader.load(serverDir);
+      ir = await ProtocolLoader.load(serverDir);
     } on ProtocolLoaderException catch (e) {
       stderr.writeln(e.message);
       return 70;
@@ -91,11 +94,19 @@ class GenerateCommand extends Command<int> {
     final scaffold = ScaffoldEmitter(
       outputPaths: paths,
       tracker: tracker,
+      additionalBarrelExports: const ["./protocol/index.js"],
     );
     await scaffold.emit();
 
-    // Sweep orphans now. As model/endpoint emission lands, they'll
-    // record their writes before this sweep runs.
+    final modelEmitter = ModelEmitter(
+      outputDir: paths.outputDir,
+      tracker: tracker,
+      mapper: TsTypeMapper(),
+    );
+    modelEmitter.emitAll(ir.models);
+
+    // Sweep orphans now. As endpoint emission lands, it'll record its
+    // writes before this sweep runs.
     tracker.sweepOrphans();
 
     stdout.writeln('Wrote TypeScript client to ${paths.outputDir.path}');

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -1,0 +1,368 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+
+import 'generated_file_tracker.dart';
+import 'ts_type_mapper.dart';
+import 'ts_writer.dart';
+
+const _generatedHeader = '''
+// AUTOMATICALLY GENERATED — DO NOT EDIT BY HAND
+// To regenerate, run: dart run serverpod_typescript_bridge generate
+''';
+
+/// Emits one TypeScript file per Serverpod model — class, enum, or
+/// exception. Sealed hierarchies are out of scope for this pass; that
+/// emitter is added in issue #6.
+class ModelEmitter {
+  ModelEmitter({
+    required this.outputDir,
+    required this.tracker,
+    required this.mapper,
+  });
+
+  final Directory outputDir;
+  final GeneratedFileTracker tracker;
+  final TsTypeMapper mapper;
+
+  /// Emits every non-sealed model in [models], plus a `protocol/index.ts`
+  /// barrel re-exporting them all. Returns the list of emitted basenames
+  /// (without the `.ts` suffix), in alphabetical order.
+  List<String> emitAll(List<SerializableModelDefinition> models) {
+    final emitted = <String>[];
+    final classNames = <String>[];
+    for (final model in models) {
+      if (model is ModelClassDefinition) {
+        if (model.isSealed) continue; // Issue #6.
+        emitted.add(_emitClass(model));
+        classNames.add(model.className);
+      } else if (model is ExceptionClassDefinition) {
+        emitted.add(_emitException(model));
+        classNames.add(model.className);
+      } else if (model is EnumDefinition) {
+        emitted.add(_emitEnum(model));
+        classNames.add(model.className);
+      }
+    }
+    emitted.sort();
+    _emitProtocolBarrel(emitted);
+    return emitted;
+  }
+
+  void _emitProtocolBarrel(List<String> filenames) {
+    final w = TsWriter()..writeRaw(_generatedHeader);
+    for (final f in filenames) {
+      final stem = f.replaceAll(RegExp(r'\.ts$'), '');
+      w.writeln("export * from './$stem.js';");
+    }
+    _writeFile('index.ts', w.toString());
+  }
+
+  String _emitClass(ModelClassDefinition model) {
+    final w = TsWriter()
+      ..writeRaw(_generatedHeader)
+      ..writeln(
+        "import * as r from '../runtime/index.js';",
+      )
+      ..blankLine();
+
+    final fields = model.fields
+        .where((f) => f.shouldIncludeField(false /* serverCode */))
+        .toList();
+
+    w.docComment(model.documentation?.join('\n'));
+    w.writeln('export class ${model.className} implements r.SerializableModel {');
+    w.indent(() {
+      // Public fields
+      for (final field in fields) {
+        w.docComment(field.documentation?.join('\n'));
+        final type = mapper.map(field.type);
+        w.writeln('${field.name}: ${type.tsType};');
+      }
+      w.blankLine();
+
+      // Constructor
+      w.writeln('constructor(init: {');
+      w.indent(() {
+        for (final field in fields) {
+          final type = mapper.map(field.type);
+          w.writeln('${field.name}: ${type.tsType};');
+        }
+      });
+      w.writeln('}) {');
+      w.indent(() {
+        for (final field in fields) {
+          w.writeln('this.${field.name} = init.${field.name};');
+        }
+      });
+      w.writeln('}');
+      w.blankLine();
+
+      // fromJson
+      w.writeln(
+        'static fromJson(json: Record<string, unknown>): ${model.className} {',
+      );
+      w.indent(() {
+        w.writeln('return new ${model.className}({');
+        w.indent(() {
+          for (final field in fields) {
+            final type = mapper.map(field.type);
+            final fromExpr =
+                type.fromJsonExpr("json['${field.name}']");
+            w.writeln('${field.name}: $fromExpr,');
+          }
+        });
+        w.writeln('});');
+      });
+      w.writeln('}');
+      w.blankLine();
+
+      // toJson
+      w.writeln('toJson(): Record<string, unknown> {');
+      w.indent(() {
+        w.writeln('return {');
+        w.indent(() {
+          w.writeln("__className__: '${model.className}',");
+          for (final field in fields) {
+            final type = mapper.map(field.type);
+            if (field.type.nullable) {
+              w.writeln(
+                '...(this.${field.name} !== null && '
+                '{ ${field.name}: ${type.toJsonExpr('this.${field.name}')} }),',
+              );
+            } else {
+              w.writeln('${field.name}: ${type.toJsonExpr('this.${field.name}')},');
+            }
+          }
+        });
+        w.writeln('};');
+      });
+      w.writeln('}');
+      w.blankLine();
+
+      // copyWith
+      w.writeln('copyWith(partial: Partial<{');
+      w.indent(() {
+        for (final field in fields) {
+          final type = mapper.map(field.type);
+          w.writeln('${field.name}: ${type.tsType};');
+        }
+      });
+      w.writeln('}>): ${model.className} {');
+      w.indent(() {
+        w.writeln('return new ${model.className}({');
+        w.indent(() {
+          for (final field in fields) {
+            // Use `??` for non-nullable fields; for nullables, let the
+            // explicit-null case fall through (caller must use partial).
+            w.writeln(
+              '${field.name}: partial.${field.name} ?? this.${field.name},',
+            );
+          }
+        });
+        w.writeln('});');
+      });
+      w.writeln('}');
+    });
+    w.writeln('}');
+
+    return _writeFile(_filenameOf(model.className), w.toString());
+  }
+
+  String _emitException(ExceptionClassDefinition model) {
+    final w = TsWriter()
+      ..writeRaw(_generatedHeader)
+      ..writeln("import * as r from '../runtime/index.js';")
+      ..blankLine();
+
+    final fields = model.fields
+        .where((f) => f.shouldIncludeField(false))
+        .toList();
+
+    w.docComment(model.documentation?.join('\n'));
+    w.writeln(
+      'export class ${model.className} extends Error implements r.SerializableException {',
+    );
+    w.indent(() {
+      for (final field in fields) {
+        w.docComment(field.documentation?.join('\n'));
+        final type = mapper.map(field.type);
+        w.writeln('readonly ${field.name}: ${type.tsType};');
+      }
+      w.blankLine();
+
+      w.writeln('constructor(init: {');
+      w.indent(() {
+        for (final field in fields) {
+          final type = mapper.map(field.type);
+          w.writeln('${field.name}: ${type.tsType};');
+        }
+      });
+      w.writeln('}) {');
+      w.indent(() {
+        // Best-effort: use `init.message` if there's a `message` field;
+        // otherwise the class name as the Error message.
+        final hasMsg = fields.any((f) => f.name == 'message');
+        if (hasMsg) {
+          w.writeln('super(init.message as string);');
+        } else {
+          w.writeln("super('${model.className}');");
+        }
+        w.writeln("this.name = '${model.className}';");
+        for (final field in fields) {
+          w.writeln('this.${field.name} = init.${field.name};');
+        }
+      });
+      w.writeln('}');
+      w.blankLine();
+
+      w.writeln(
+        'static fromJson(json: Record<string, unknown>): ${model.className} {',
+      );
+      w.indent(() {
+        w.writeln('return new ${model.className}({');
+        w.indent(() {
+          for (final field in fields) {
+            final type = mapper.map(field.type);
+            w.writeln(
+              '${field.name}: ${type.fromJsonExpr("json['${field.name}']")},',
+            );
+          }
+        });
+        w.writeln('});');
+      });
+      w.writeln('}');
+      w.blankLine();
+
+      w.writeln('toJson(): Record<string, unknown> {');
+      w.indent(() {
+        w.writeln('return {');
+        w.indent(() {
+          w.writeln("__className__: '${model.className}',");
+          for (final field in fields) {
+            final type = mapper.map(field.type);
+            w.writeln('${field.name}: ${type.toJsonExpr('this.${field.name}')},');
+          }
+        });
+        w.writeln('};');
+      });
+      w.writeln('}');
+    });
+    w.writeln('}');
+
+    return _writeFile(_filenameOf(model.className), w.toString());
+  }
+
+  String _emitEnum(EnumDefinition model) {
+    final w = TsWriter()
+      ..writeRaw(_generatedHeader)
+      ..blankLine();
+
+    w.docComment(model.documentation?.join('\n'));
+    w.writeln('export enum ${model.className} {');
+    w.indent(() {
+      for (var i = 0; i < model.values.length; i++) {
+        final v = model.values[i];
+        w.docComment(v.documentation?.join('\n'));
+        final memberName = _enumMemberName(v.name);
+        w.writeln("$memberName = '${v.name}',");
+      }
+    });
+    w.writeln('}');
+    w.blankLine();
+
+    final byIndex = model.serialized.name == 'byIndex';
+    final namespaceName = '${model.className}Codec';
+    w.writeln('export const $namespaceName = {');
+    w.indent(() {
+      // toJson
+      if (byIndex) {
+        w.writeln('toJson(value: ${model.className}): number {');
+        w.indent(() {
+          w.writeln('switch (value) {');
+          w.indent(() {
+            for (var i = 0; i < model.values.length; i++) {
+              w.writeln(
+                'case ${model.className}.${_enumMemberName(model.values[i].name)}: return $i;',
+              );
+            }
+          });
+          w.writeln('}');
+        });
+        w.writeln('},');
+      } else {
+        w.writeln(
+          'toJson(value: ${model.className}): string { return value; },',
+        );
+      }
+      w.blankLine();
+      // fromJson
+      w.writeln('fromJson(json: unknown): ${model.className} {');
+      w.indent(() {
+        if (byIndex) {
+          w.writeln(
+            "if (typeof json !== 'number') throw new Error('Expected number for ${model.className}, got ' + typeof json);",
+          );
+          w.writeln('switch (json) {');
+          w.indent(() {
+            for (var i = 0; i < model.values.length; i++) {
+              w.writeln(
+                'case $i: return ${model.className}.${_enumMemberName(model.values[i].name)};',
+              );
+            }
+            w.writeln(
+              "default: throw new Error('Unknown ${model.className} index: ' + json);",
+            );
+          });
+          w.writeln('}');
+        } else {
+          w.writeln(
+            "if (typeof json !== 'string') throw new Error('Expected string for ${model.className}, got ' + typeof json);",
+          );
+          w.writeln('switch (json) {');
+          w.indent(() {
+            for (final v in model.values) {
+              w.writeln(
+                "case '${v.name}': return ${model.className}.${_enumMemberName(v.name)};",
+              );
+            }
+            w.writeln(
+              "default: throw new Error('Unknown ${model.className} name: ' + json);",
+            );
+          });
+          w.writeln('}');
+        }
+      });
+      w.writeln('},');
+    });
+    w.writeln('};');
+
+    return _writeFile(_filenameOf(model.className), w.toString());
+  }
+
+  String _filenameOf(String className) {
+    final snake = className
+        .replaceAllMapped(RegExp(r'[A-Z]'), (m) => '_${m[0]!.toLowerCase()}')
+        .replaceFirst(RegExp(r'^_'), '');
+    return '$snake.ts';
+  }
+
+  String _enumMemberName(String name) {
+    // TS enum members are valid identifiers; the value names from
+    // Serverpod YAML are already valid Dart identifiers, so simple
+    // capitalisation is safe.
+    if (name.isEmpty) return name;
+    return name[0].toUpperCase() + name.substring(1);
+  }
+
+  String _writeFile(String filename, String content) {
+    final destDir = Directory(p.join(outputDir.path, 'src', 'protocol'));
+    destDir.createSync(recursive: true);
+    final file = File(p.join(destDir.path, filename));
+    file.writeAsStringSync(content);
+    tracker.recordWrite(file);
+    return filename;
+  }
+}

--- a/lib/src/emit/scaffold_emitter.dart
+++ b/lib/src/emit/scaffold_emitter.dart
@@ -16,10 +16,15 @@ class ScaffoldEmitter {
   ScaffoldEmitter({
     required this.outputPaths,
     required this.tracker,
+    this.additionalBarrelExports = const [],
   });
 
   final OutputPaths outputPaths;
   final GeneratedFileTracker tracker;
+
+  /// Extra re-exports the barrel `src/index.ts` should include beyond
+  /// the runtime — e.g. `./protocol/index.js` once model emission lands.
+  final List<String> additionalBarrelExports;
 
   Future<void> emit() async {
     outputPaths.outputDir.createSync(recursive: true);
@@ -43,14 +48,13 @@ class ScaffoldEmitter {
   }
 
   void _writeIndexBarrel() {
-    // For now the barrel re-exports only the runtime. Model and
-    // endpoint emission (issues #5–#8) will append their re-exports
-    // here at write-time.
-    _writeRelative(
-      'src/index.ts',
-      "// Public surface of the generated client.\n"
-      "export * from './runtime/index.js';\n",
-    );
+    final lines = StringBuffer()
+      ..writeln('// Public surface of the generated client.')
+      ..writeln("export * from './runtime/index.js';");
+    for (final extra in additionalBarrelExports) {
+      lines.writeln("export * from '$extra';");
+    }
+    _writeRelative('src/index.ts', lines.toString());
   }
 
   Future<void> _copyRuntime() async {

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -1,0 +1,159 @@
+// ignore_for_file: implementation_imports
+import 'package:serverpod_cli/analyzer.dart';
+
+/// A TypeScript type reference plus the JSON conversion expressions that
+/// turn a value of that type into wire form (and back).
+class TsTypeRef {
+  TsTypeRef({
+    required this.tsType,
+    required this.toJsonExpr,
+    required this.fromJsonExpr,
+  });
+
+  /// The fully-qualified TS type, e.g. `string | null` or `User[]`.
+  final String tsType;
+
+  /// Builds a `toJson` expression for a Dart value of this type, given
+  /// a TS source variable name.
+  final String Function(String sourceVarName) toJsonExpr;
+
+  /// Builds a `fromJson` expression that parses a raw JSON value
+  /// (typically `unknown`) back into the typed value.
+  final String Function(String sourceVarName) fromJsonExpr;
+}
+
+/// Maps a Serverpod analyzer [TypeDefinition] to its TypeScript
+/// counterpart. Per the canonical mapping table in
+/// [docs/architecture.md](../../../docs/architecture.md).
+class TsTypeMapper {
+  TsTypeRef map(TypeDefinition type) {
+    final base = _mapInner(type);
+    if (!type.nullable) return base;
+    return TsTypeRef(
+      tsType: '${base.tsType} | null',
+      toJsonExpr: (v) => '$v === null ? null : ${base.toJsonExpr(v)}',
+      fromJsonExpr: (v) =>
+          '$v === null || $v === undefined ? null : ${base.fromJsonExpr(v)}',
+    );
+  }
+
+  TsTypeRef _mapInner(TypeDefinition type) {
+    switch (type.className) {
+      case 'int':
+      case 'double':
+      case 'num':
+        return _passthrough('number');
+      case 'String':
+        return _passthrough('string');
+      case 'bool':
+        return TsTypeRef(
+          tsType: 'boolean',
+          toJsonExpr: (v) => v,
+          fromJsonExpr: (v) => 'r.decodeBool($v)',
+        );
+      case 'DateTime':
+        return TsTypeRef(
+          tsType: 'Date',
+          toJsonExpr: (v) => 'r.encodeDateTime($v)',
+          fromJsonExpr: (v) => 'r.decodeDateTime($v)',
+        );
+      case 'Duration':
+        return TsTypeRef(
+          tsType: 'number',
+          toJsonExpr: (v) => 'r.encodeDuration($v)',
+          fromJsonExpr: (v) => 'r.decodeDuration($v)',
+        );
+      case 'BigInt':
+        return TsTypeRef(
+          tsType: 'bigint',
+          toJsonExpr: (v) => 'r.encodeBigInt($v)',
+          fromJsonExpr: (v) => 'r.decodeBigInt($v)',
+        );
+      case 'UuidValue':
+      case 'Uri':
+        return _passthrough('string');
+      case 'ByteData':
+      case 'Uint8List':
+        return TsTypeRef(
+          tsType: 'Uint8Array',
+          toJsonExpr: (v) => 'r.encodeBytes($v)',
+          fromJsonExpr: (v) => 'r.decodeBytes($v)',
+        );
+      case 'List':
+        return _mapList(type);
+      case 'Set':
+        return _mapSet(type);
+      case 'Map':
+        return _mapMap(type);
+      default:
+        return _mapModelOrEnum(type);
+    }
+  }
+
+  TsTypeRef _passthrough(String tsType) {
+    return TsTypeRef(
+      tsType: tsType,
+      toJsonExpr: (v) => v,
+      fromJsonExpr: (v) => '$v as $tsType',
+    );
+  }
+
+  TsTypeRef _mapList(TypeDefinition type) {
+    final elem = map(type.generics.first);
+    return TsTypeRef(
+      tsType: '${_parens(elem.tsType)}[]',
+      toJsonExpr: (v) =>
+          'r.encodeList($v, (x: ${elem.tsType}) => ${elem.toJsonExpr('x')})',
+      fromJsonExpr: (v) =>
+          'r.decodeList($v, (x: unknown) => ${elem.fromJsonExpr('x')})',
+    );
+  }
+
+  TsTypeRef _mapSet(TypeDefinition type) {
+    final elem = map(type.generics.first);
+    return TsTypeRef(
+      tsType: 'Set<${elem.tsType}>',
+      toJsonExpr: (v) =>
+          'r.encodeSet($v, (x: ${elem.tsType}) => ${elem.toJsonExpr('x')})',
+      fromJsonExpr: (v) =>
+          'r.decodeSet($v, (x: unknown) => ${elem.fromJsonExpr('x')})',
+    );
+  }
+
+  TsTypeRef _mapMap(TypeDefinition type) {
+    final key = map(type.generics[0]);
+    final value = map(type.generics[1]);
+    final isStringKeyed = type.generics[0].className == 'String';
+    if (isStringKeyed) {
+      return TsTypeRef(
+        tsType: 'Record<string, ${value.tsType}>',
+        toJsonExpr: (v) =>
+            'r.encodeMap($v, (x: ${value.tsType}) => ${value.toJsonExpr('x')})',
+        fromJsonExpr: (v) =>
+            'r.decodeMap($v, (x: unknown) => x as string, (x: unknown) => ${value.fromJsonExpr('x')})',
+      );
+    }
+    return TsTypeRef(
+      tsType: 'Map<${key.tsType}, ${value.tsType}>',
+      toJsonExpr: (v) =>
+          'r.encodeMap($v, (x: ${value.tsType}) => ${value.toJsonExpr('x')})',
+      fromJsonExpr: (v) =>
+          'r.decodeMap($v, (x: unknown) => ${key.fromJsonExpr('x')}, (x: unknown) => ${value.fromJsonExpr('x')})',
+    );
+  }
+
+  TsTypeRef _mapModelOrEnum(TypeDefinition type) {
+    // Models, enums, exceptions, and other project types are emitted
+    // by ModelEmitter under the same className. The default contract:
+    //   toJson()       → calls .toJson() on the instance
+    //   fromJson(json) → static <ClassName>.fromJson(json)
+    final cls = type.className;
+    return TsTypeRef(
+      tsType: cls,
+      toJsonExpr: (v) => '$v.toJson()',
+      fromJsonExpr: (v) => '$cls.fromJson($v as Record<string, unknown>)',
+    );
+  }
+
+  String _parens(String t) => t.contains(' ') || t.contains('|') ? '($t)' : t;
+}

--- a/lib/src/emit/ts_writer.dart
+++ b/lib/src/emit/ts_writer.dart
@@ -1,0 +1,66 @@
+/// Indent-aware string buffer for emitting TypeScript files.
+///
+/// Deliberately minimal — just enough for our emitter to stay readable
+/// without pulling in a full AST library.
+class TsWriter {
+  final StringBuffer _buf = StringBuffer();
+  int _depth = 0;
+  static const _indentUnit = '  ';
+
+  /// Writes [text] at the current indent, followed by a newline.
+  void writeln([String text = '']) {
+    if (text.isEmpty) {
+      _buf.writeln();
+      return;
+    }
+    _buf
+      ..write(_indentUnit * _depth)
+      ..writeln(text);
+  }
+
+  /// Writes [text] *raw* — no indent prefix, no trailing newline.
+  void writeRaw(String text) {
+    _buf.write(text);
+  }
+
+  /// Writes a blank line.
+  void blankLine() {
+    _buf.writeln();
+  }
+
+  /// Indents one level for the duration of [body].
+  void indent(void Function() body) {
+    _depth += 1;
+    try {
+      body();
+    } finally {
+      _depth -= 1;
+    }
+  }
+
+  /// Writes [docComment] as a TSDoc block (`/** … */`) above the next
+  /// declaration. No-op for null/empty docs.
+  void docComment(String? docComment) {
+    if (docComment == null || docComment.trim().isEmpty) return;
+    final lines = docComment
+        .split('\n')
+        .map((l) => l.replaceFirst(RegExp(r'^/// ?'), ''))
+        .toList();
+    if (lines.length == 1) {
+      writeln('/** ${lines.single} */');
+      return;
+    }
+    writeln('/**');
+    for (final line in lines) {
+      if (line.isEmpty) {
+        writeln(' *');
+      } else {
+        writeln(' * $line');
+      }
+    }
+    writeln(' */');
+  }
+
+  @override
+  String toString() => _buf.toString();
+}

--- a/test/ts_writer_test.dart
+++ b/test/ts_writer_test.dart
@@ -1,0 +1,52 @@
+import 'package:serverpod_typescript_bridge/src/emit/ts_writer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TsWriter', () {
+    test('writeln writes content with the current indent and a newline', () {
+      final w = TsWriter()..writeln('hello');
+      expect(w.toString(), 'hello\n');
+    });
+
+    test('blankLine emits exactly one newline with no indent', () {
+      final w = TsWriter()..blankLine();
+      expect(w.toString(), '\n');
+    });
+
+    test('indent body is indented two spaces per level', () {
+      final w = TsWriter()..writeln('outer');
+      w.indent(() => w.writeln('inner'));
+      expect(w.toString(), 'outer\n  inner\n');
+    });
+
+    test('indent restores depth even after exception in body', () {
+      final w = TsWriter();
+      expect(
+        () => w.indent(() => throw StateError('boom')),
+        throwsA(isA<StateError>()),
+      );
+      w.writeln('after');
+      expect(w.toString(), 'after\n',
+          reason: 'depth should have been restored to 0');
+    });
+
+    test('docComment emits a single-line TSDoc for one line of input', () {
+      final w = TsWriter()..docComment('A brief doc.');
+      expect(w.toString(), '/** A brief doc. */\n');
+    });
+
+    test(
+        'docComment strips Dart `///` prefixes and emits a multi-line block',
+        () {
+      final w = TsWriter()..docComment('/// First line.\n/// Second line.');
+      expect(w.toString(), '/**\n * First line.\n * Second line.\n */\n');
+    });
+
+    test('docComment is a no-op for null and empty input', () {
+      final empty = TsWriter()..docComment(null);
+      expect(empty.toString(), '');
+      final blank = TsWriter()..docComment('   ');
+      expect(blank.toString(), '');
+    });
+  });
+}


### PR DESCRIPTION
Closes #5

## Summary

Layered model emission on top of the issue #4 scaffold. Generated client now contains one TS file per Serverpod model — class, enum, or exception — under `src/protocol/`, plus a barrel that the top-level `src/index.ts` re-exports.

## What lands

- **`TsWriter`** — indent-aware string buffer with a TSDoc helper that strips Dart `///` prefixes and emits single- or multi-line `/** … */` blocks.
- **`TsTypeMapper`** — `TypeDefinition` → `TsTypeRef` (TS type + `toJson` + `fromJson` expressions). Covers every primitive, collection, and nullable in the architecture doc. All runtime helper calls are prefixed `r.` to match the `import * as r from '../runtime/...'` convention emitted by `ModelEmitter`.
- **`ModelEmitter`** — emits classes (fields + constructor + `fromJson` + `toJson` + `copyWith`), enums (`byIndex` + `byName` codecs), exceptions (`extends Error implements SerializableException`). Sealed hierarchies are skipped — those land in #6.
- **`ScaffoldEmitter`** now accepts `additionalBarrelExports` so the top-level `src/index.ts` can also re-export the protocol barrel.
- **`GenerateCommand`** wires the model emitter into the pipeline; the IR is now load-bearing for emission, not just a fail-fast check.

## Tests

- 7 unit cases for `TsWriter` (writeln, blankLine, indent + scope-restore, docComment for null/single/multi-line).
- The existing e2e test now confirms `tsc --noEmit` clean against the fixture's 7 model classes (UserProfile, AdminProfile, Dog, Cat, Priority, Colour, NotFoundException). Sealed `Animal` correctly skipped (issue #6).
- Full dart suite: 76/76 passing.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart test` — 76/76 passing
- [x] e2e: generated package compiles with `tsc --noEmit` against the fixture
