### PR TITLE
feat(#7): endpoint emission (unary HTTP)

### DIFF
--- a/lib/runtime/typescript/src/serialization.ts
+++ b/lib/runtime/typescript/src/serialization.ts
@@ -157,6 +157,25 @@ export function encodeMap<K, V>(
   return out;
 }
 
+/// String-keyed sibling of [decodeMap] that returns a plain
+/// JavaScript object — generated client code for `Map<String, V>`
+/// uses this to keep the ergonomic `Record<string, V>` TS type.
+export function decodeRecord<V>(
+  json: unknown,
+  valueDecoder: (raw: unknown) => V,
+): Record<string, V> {
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    throw new TypeError(
+      `Cannot decode Record from ${typeof json}: ${JSON.stringify(json)}`,
+    );
+  }
+  const out: Record<string, V> = {};
+  for (const [k, v] of Object.entries(json as Record<string, unknown>)) {
+    out[k] = valueDecoder(v);
+  }
+  return out;
+}
+
 export function decodeMap<K, V>(
   json: unknown,
   keyDecoder: (raw: unknown) => K,

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -9,6 +9,7 @@ import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import '../analyzer/protocol_loader.dart';
 import '../discovery/server_directory_finder.dart';
 import '../emit/generated_file_tracker.dart';
+import '../emit/endpoint_emitter.dart';
 import '../emit/model_emitter.dart';
 import '../emit/output_paths.dart';
 import '../emit/scaffold_emitter.dart';
@@ -94,16 +95,31 @@ class GenerateCommand extends Command<int> {
     final scaffold = ScaffoldEmitter(
       outputPaths: paths,
       tracker: tracker,
-      additionalBarrelExports: const ["./protocol/index.js"],
+      additionalBarrelExports: const [
+        './protocol/index.js',
+        './endpoints/index.js',
+      ],
     );
     await scaffold.emit();
 
-    final modelEmitter = ModelEmitter(
+    final sealedClassNames = ir.models
+        .whereType<ModelClassDefinition>()
+        .where((m) => m.isSealed)
+        .map((m) => m.className)
+        .toSet();
+    ModelEmitter(
       outputDir: paths.outputDir,
       tracker: tracker,
-      mapper: TsTypeMapper(),
-    );
-    modelEmitter.emitAll(ir.models);
+      mapper: TsTypeMapper(sealedClassNames: sealedClassNames),
+    ).emitAll(ir.models);
+    EndpointEmitter(
+      outputDir: paths.outputDir,
+      tracker: tracker,
+      mapper: TsTypeMapper(
+        modelPrefix: 'p.',
+        sealedClassNames: sealedClassNames,
+      ),
+    ).emitAll(ir.endpoints);
 
     // Sweep orphans now. As endpoint emission lands, it'll record its
     // writes before this sweep runs.

--- a/lib/src/emit/endpoint_emitter.dart
+++ b/lib/src/emit/endpoint_emitter.dart
@@ -1,0 +1,228 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+
+import 'generated_file_tracker.dart';
+import 'ts_type_mapper.dart';
+import 'ts_writer.dart';
+
+const _generatedHeader = '''
+// AUTOMATICALLY GENERATED — DO NOT EDIT BY HAND
+// To regenerate, run: dart run serverpod_typescript_bridge generate
+''';
+
+/// Emits one TS file per Serverpod endpoint, plus an `endpoints/index.ts`
+/// barrel re-exporting them all. Streaming methods emit a stub that
+/// throws — real streaming support is added in issue #10.
+class EndpointEmitter {
+  EndpointEmitter({
+    required this.outputDir,
+    required this.tracker,
+    required this.mapper,
+  });
+
+  final Directory outputDir;
+  final GeneratedFileTracker tracker;
+  final TsTypeMapper mapper;
+
+  /// Emits every concrete endpoint in [endpoints]. Returns the list of
+  /// emitted basenames (without the `.ts` suffix), in alphabetical order.
+  List<String> emitAll(List<EndpointDefinition> endpoints) {
+    final emitted = <String>[];
+    for (final ep in endpoints) {
+      if (ep.isAbstract) continue;
+      emitted.add(_emitEndpoint(ep));
+    }
+    emitted.sort();
+    _emitBarrel(emitted);
+    return emitted;
+  }
+
+  void _emitBarrel(List<String> filenames) {
+    final w = TsWriter()..writeRaw(_generatedHeader);
+    for (final f in filenames) {
+      final stem = f.replaceAll(RegExp(r'\.ts$'), '');
+      w.writeln("export * from './$stem.js';");
+    }
+    _writeFile('index.ts', w.toString());
+  }
+
+  String _emitEndpoint(EndpointDefinition ep) {
+    final w = TsWriter()
+      ..writeRaw(_generatedHeader)
+      ..writeln("import * as r from '../runtime/index.js';")
+      ..writeln("import * as p from '../protocol/index.js';")
+      ..blankLine();
+
+    final className = 'Endpoint${_pascalCase(ep.name)}';
+
+    w.docComment(ep.documentationComment);
+    w.writeln('export class $className extends r.EndpointRef {');
+    w.indent(() {
+      w.writeln("override get name(): string { return '${ep.name}'; }");
+      w.blankLine();
+
+      for (final method in ep.methods) {
+        _emitMethod(w, ep, method);
+      }
+    });
+    w.writeln('}');
+
+    return _writeFile('endpoint_${_filenameStem(ep.name)}.ts', w.toString());
+  }
+
+  void _emitMethod(TsWriter w, EndpointDefinition ep, MethodDefinition method) {
+    w.docComment(method.documentationComment);
+    final isDeprecated =
+        method.annotations.any((a) => a.name == 'Deprecated' || a.name == 'deprecated');
+    if (isDeprecated) w.writeln('/** @deprecated */');
+
+    final isStreaming = method is MethodStreamDefinition ||
+        method.parameters.any((p) => p.type.className == 'Stream') ||
+        method.parametersPositional.any((p) => p.type.className == 'Stream') ||
+        method.parametersNamed.any((p) => p.type.className == 'Stream');
+
+    final signature = _buildSignature(method);
+    w.writeln('async ${method.name}(${signature.params}): ${signature.returnType} {');
+    w.indent(() {
+      if (isStreaming) {
+        w.writeln(
+          "throw new Error('Streaming endpoint methods are not supported in v0.1 — see issue #10.');",
+        );
+        return;
+      }
+      _emitMethodBody(w, ep, method, signature);
+    });
+    w.writeln('}');
+    w.blankLine();
+  }
+
+  _Signature _buildSignature(MethodDefinition method) {
+    final params = <String>[];
+    for (final p in method.parameters) {
+      params.add('${_safe(p.name)}: ${mapper.map(p.type).tsType}');
+    }
+    for (final p in method.parametersPositional) {
+      params.add('${_safe(p.name)}?: ${mapper.map(p.type).tsType}');
+    }
+    if (method.parametersNamed.isNotEmpty) {
+      final inner = method.parametersNamed
+          .map((p) {
+            final tsType = mapper.map(p.type).tsType;
+            return p.required
+                ? '${_safe(p.name)}: $tsType'
+                : '${_safe(p.name)}?: $tsType';
+          })
+          .join('; ');
+      params.add('named: { $inner }');
+    }
+
+    final returnInner = _futureInner(method.returnType);
+    final tsReturn = mapper.map(returnInner).tsType;
+    final asyncReturn = tsReturn == 'void' ? 'Promise<void>' : 'Promise<$tsReturn>';
+
+    return _Signature(
+      params: params.join(', '),
+      returnType: asyncReturn,
+      returnInner: returnInner,
+      tsReturnInner: tsReturn,
+    );
+  }
+
+  void _emitMethodBody(
+    TsWriter w,
+    EndpointDefinition ep,
+    MethodDefinition method,
+    _Signature signature,
+  ) {
+    final argEntries = <String>[];
+    for (final p in method.parameters) {
+      argEntries.add('${_safe(p.name)}: ${_safe(p.name)}');
+    }
+    for (final p in method.parametersPositional) {
+      argEntries.add('${_safe(p.name)}: ${_safe(p.name)}');
+    }
+    for (final p in method.parametersNamed) {
+      argEntries.add('${_safe(p.name)}: named.${_safe(p.name)}');
+    }
+
+    final isVoid = signature.tsReturnInner == 'void';
+    final decode = isVoid
+        ? '() => undefined as void'
+        : '(raw: unknown) => ${mapper.map(signature.returnInner).fromJsonExpr('raw')}';
+
+    final isUnauth = method.annotations
+        .any((a) => a.name == 'unauthenticatedClientCall');
+    final optionsArg = isUnauth ? ', { authenticated: false }' : '';
+
+    w.writeln(
+      "return this.caller.callServerEndpoint<${signature.tsReturnInner}>(",
+    );
+    w.indent(() {
+      w.writeln("'${ep.name}',");
+      w.writeln("'${method.name}',");
+      if (argEntries.isEmpty) {
+        w.writeln('{},');
+      } else {
+        w.writeln('{ ${argEntries.join(', ')} },');
+      }
+      w.writeln('$decode$optionsArg,');
+    });
+    w.writeln(');');
+  }
+
+  TypeDefinition _futureInner(TypeDefinition t) {
+    if ((t.className == 'Future' || t.className == 'Stream') &&
+        t.generics.isNotEmpty) {
+      return t.generics.first;
+    }
+    return t;
+  }
+
+  String _safe(String name) {
+    const reserved = {
+      'class', 'default', 'enum', 'interface', 'extends', 'super',
+      'package', 'private', 'protected', 'public', 'static',
+      'await', 'yield', 'function', 'return', 'this', 'new',
+    };
+    return reserved.contains(name) ? '${name}_' : name;
+  }
+
+  String _pascalCase(String s) {
+    if (s.isEmpty) return s;
+    return s[0].toUpperCase() + s.substring(1);
+  }
+
+  String _filenameStem(String name) {
+    return name.replaceAllMapped(
+      RegExp(r'[A-Z]'),
+      (m) => '_${m[0]!.toLowerCase()}',
+    );
+  }
+
+  String _writeFile(String filename, String content) {
+    final destDir = Directory(p.join(outputDir.path, 'src', 'endpoints'));
+    destDir.createSync(recursive: true);
+    final file = File(p.join(destDir.path, filename));
+    file.writeAsStringSync(content);
+    tracker.recordWrite(file);
+    return filename;
+  }
+}
+
+class _Signature {
+  _Signature({
+    required this.params,
+    required this.returnType,
+    required this.returnInner,
+    required this.tsReturnInner,
+  });
+
+  final String params;
+  final String returnType;
+  final TypeDefinition returnInner;
+  final String tsReturnInner;
+}

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -25,7 +25,25 @@ class TsTypeRef {
 /// Maps a Serverpod analyzer [TypeDefinition] to its TypeScript
 /// counterpart. Per the canonical mapping table in
 /// [docs/architecture.md](../../../docs/architecture.md).
+///
+/// [modelPrefix] is prepended to project-model TS types and `fromJson`
+/// calls — used by the endpoint emitter to reach across into the
+/// protocol barrel (`p.UserProfile.fromJson(...)`). Model emitters
+/// that already live inside the protocol directory pass an empty
+/// prefix.
 class TsTypeMapper {
+  TsTypeMapper({
+    this.modelPrefix = '',
+    Set<String>? sealedClassNames,
+  }) : sealedClassNames = sealedClassNames ?? const {};
+
+  final String modelPrefix;
+
+  /// Class names that were emitted as sealed bases. References to these
+  /// types still use the bare name (the discriminated-union alias), but
+  /// `fromJson` routes through `<Name>Base` (the abstract dispatcher).
+  final Set<String> sealedClassNames;
+
   TsTypeRef map(TypeDefinition type) {
     final base = _mapInner(type);
     if (!type.nullable) return base;
@@ -85,6 +103,16 @@ class TsTypeMapper {
         return _mapSet(type);
       case 'Map':
         return _mapMap(type);
+      case 'Future':
+      case 'Stream':
+        // Streaming params/returns are stubbed by the endpoint emitter,
+        // so the precise type doesn't matter at the call site — but we
+        // still need a TS placeholder that compiles.
+        return TsTypeRef(
+          tsType: 'unknown',
+          toJsonExpr: (v) => v,
+          fromJsonExpr: (v) => v,
+        );
       default:
         return _mapModelOrEnum(type);
     }
@@ -130,7 +158,7 @@ class TsTypeMapper {
         toJsonExpr: (v) =>
             'r.encodeMap($v, (x: ${value.tsType}) => ${value.toJsonExpr('x')})',
         fromJsonExpr: (v) =>
-            'r.decodeMap($v, (x: unknown) => x as string, (x: unknown) => ${value.fromJsonExpr('x')})',
+            'r.decodeRecord($v, (x: unknown) => ${value.fromJsonExpr('x')})',
       );
     }
     return TsTypeRef(
@@ -144,14 +172,18 @@ class TsTypeMapper {
 
   TsTypeRef _mapModelOrEnum(TypeDefinition type) {
     // Models, enums, exceptions, and other project types are emitted
-    // by ModelEmitter under the same className. The default contract:
-    //   toJson()       → calls .toJson() on the instance
-    //   fromJson(json) → static <ClassName>.fromJson(json)
-    final cls = type.className;
+    // by ModelEmitter under the same className. Sealed bases route
+    // `fromJson` through `<Name>Base` (the abstract dispatcher); the
+    // type itself is the bare union alias.
+    final qualifiedType = '$modelPrefix${type.className}';
+    final fromJsonReceiver = sealedClassNames.contains(type.className)
+        ? '$modelPrefix${type.className}Base'
+        : qualifiedType;
     return TsTypeRef(
-      tsType: cls,
+      tsType: qualifiedType,
       toJsonExpr: (v) => '$v.toJson()',
-      fromJsonExpr: (v) => '$cls.fromJson($v as Record<string, unknown>)',
+      fromJsonExpr: (v) =>
+          '$fromJsonReceiver.fromJson($v as Record<string, unknown>)',
     );
   }
 


### PR DESCRIPTION
Closes #7. Generated client now contains one TS class per Serverpod endpoint under `src/endpoints/`, plus a barrel re-exported by the top-level `src/index.ts`. Streaming methods stub-throw (real impl in #10). E2e: fixture's 9 endpoints (52 methods incl. 2 streaming stubs) compile cleanly under `tsc --noEmit`. Runtime: 58/58 vitest still green.