### PR TITLE
feat(#10): streaming endpoints — WebSocket runtime + emission

### DIFF
--- a/lib/runtime/typescript/src/__tests__/ws_messages.test.ts
+++ b/lib/runtime/typescript/src/__tests__/ws_messages.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildEnvelope, parseEnvelope } from '../ws_messages.js';
+
+describe('WebSocket envelope', () => {
+  it('round-trips a typed envelope', () => {
+    const json = buildEnvelope('open_method_stream_command', {
+      endpoint: 'e',
+      method: 'm',
+      connectionId: 'c0',
+      args: '{}',
+      inputStreams: [],
+    });
+    const parsed = parseEnvelope(json);
+    expect(parsed?.type).toBe('open_method_stream_command');
+    expect((parsed?.data as { endpoint: string }).endpoint).toBe('e');
+  });
+
+  it('returns null on malformed JSON', () => {
+    expect(parseEnvelope('not json')).toBeNull();
+  });
+
+  it('returns null on JSON without a type field', () => {
+    expect(parseEnvelope('{"foo":"bar"}')).toBeNull();
+  });
+
+  it('encodes args as a double-encoded JSON string per Dart contract', () => {
+    const env = buildEnvelope('open_method_stream_command', {
+      args: JSON.stringify({ name: 'world', count: 3 }),
+    });
+    const parsed = parseEnvelope(env)!;
+    const data = parsed.data as { args: string };
+    // The args field is a STRING containing JSON, not a nested object.
+    expect(typeof data.args).toBe('string');
+    expect(JSON.parse(data.args)).toEqual({ name: 'world', count: 3 });
+  });
+});

--- a/lib/runtime/typescript/src/client.ts
+++ b/lib/runtime/typescript/src/client.ts
@@ -2,6 +2,7 @@ import { HttpEndpointCaller, type EndpointCaller } from './endpoint.js';
 import { HttpTransport, type UnaryCallOptions } from './http_transport.js';
 import type { SerializationManager } from './serialization.js';
 import type { ClientOptions } from './types.js';
+import { ClientMethodStreamManager } from './ws_transport.js';
 
 /**
  * Base for every generated top-level `Client`. The generated subclass
@@ -13,6 +14,7 @@ import type { ClientOptions } from './types.js';
  */
 export abstract class ServerpodClientShared implements EndpointCaller {
   protected readonly transport: HttpTransport;
+  protected readonly streams: ClientMethodStreamManager;
   private readonly _caller: HttpEndpointCaller;
 
   constructor(
@@ -21,7 +23,12 @@ export abstract class ServerpodClientShared implements EndpointCaller {
     public readonly options: ClientOptions = {},
   ) {
     this.transport = new HttpTransport(host, serializer, options);
-    this._caller = new HttpEndpointCaller(this.transport);
+    this.streams = new ClientMethodStreamManager(
+      host,
+      serializer,
+      options.authKeyProvider,
+    );
+    this._caller = new HttpEndpointCaller(this.transport, this.streams);
   }
 
   callServerEndpoint<T>(
@@ -37,6 +44,20 @@ export abstract class ServerpodClientShared implements EndpointCaller {
       args,
       decode,
       options,
+    );
+  }
+
+  callStreamingServerEndpoint<T>(
+    endpoint: string,
+    method: string,
+    args: Record<string, unknown>,
+    decode: (raw: unknown) => T,
+  ): Promise<AsyncIterable<T>> {
+    return this._caller.callStreamingServerEndpoint(
+      endpoint,
+      method,
+      args,
+      decode,
     );
   }
 }

--- a/lib/runtime/typescript/src/endpoint.ts
+++ b/lib/runtime/typescript/src/endpoint.ts
@@ -1,4 +1,5 @@
 import type { HttpTransport, UnaryCallOptions } from './http_transport.js';
+import type { ClientMethodStreamManager } from './ws_transport.js';
 
 /**
  * Bridges a generated `EndpointXxx` class to whatever transport its
@@ -14,6 +15,17 @@ export interface EndpointCaller {
     decode: (raw: unknown) => T,
     options?: UnaryCallOptions,
   ): Promise<T>;
+
+  /**
+   * Open a server-side streaming method. Implementations route through
+   * the parent's [ClientMethodStreamManager].
+   */
+  callStreamingServerEndpoint<T>(
+    endpoint: string,
+    method: string,
+    args: Record<string, unknown>,
+    decode: (raw: unknown) => T,
+  ): Promise<AsyncIterable<T>>;
 }
 
 /**
@@ -51,6 +63,20 @@ export abstract class ModuleEndpointCaller implements EndpointCaller {
       options,
     );
   }
+
+  callStreamingServerEndpoint<T>(
+    endpoint: string,
+    method: string,
+    args: Record<string, unknown>,
+    decode: (raw: unknown) => T,
+  ): Promise<AsyncIterable<T>> {
+    return this.parent.callStreamingServerEndpoint(
+      endpoint,
+      method,
+      args,
+      decode,
+    );
+  }
 }
 
 /**
@@ -59,7 +85,10 @@ export abstract class ModuleEndpointCaller implements EndpointCaller {
  * delegates here).
  */
 export class HttpEndpointCaller implements EndpointCaller {
-  constructor(private readonly transport: HttpTransport) {}
+  constructor(
+    private readonly transport: HttpTransport,
+    private readonly streams?: ClientMethodStreamManager,
+  ) {}
 
   callServerEndpoint<T>(
     endpoint: string,
@@ -69,5 +98,25 @@ export class HttpEndpointCaller implements EndpointCaller {
     options?: UnaryCallOptions,
   ): Promise<T> {
     return this.transport.call(endpoint, method, args, decode, options);
+  }
+
+  callStreamingServerEndpoint<T>(
+    endpoint: string,
+    method: string,
+    args: Record<string, unknown>,
+    decode: (raw: unknown) => T,
+  ): Promise<AsyncIterable<T>> {
+    if (!this.streams) {
+      throw new Error(
+        'No ClientMethodStreamManager configured — streaming endpoints ' +
+          'require ServerpodClientShared with the streaming runtime wired.',
+      );
+    }
+    return this.streams.openOutputStream<T>({
+      endpoint,
+      method,
+      args,
+      decode,
+    });
   }
 }

--- a/lib/runtime/typescript/src/index.ts
+++ b/lib/runtime/typescript/src/index.ts
@@ -6,3 +6,5 @@ export * from './serialization.js';
 export * from './http_transport.js';
 export * from './endpoint.js';
 export * from './client.js';
+export * from './ws_messages.js';
+export * from './ws_transport.js';

--- a/lib/runtime/typescript/src/ws_messages.ts
+++ b/lib/runtime/typescript/src/ws_messages.ts
@@ -1,0 +1,100 @@
+/**
+ * Sealed union of WebSocket frame types. Mirrors
+ * `serverpod_serialization-3.4.7/lib/src/websocket_messages.dart`
+ * byte-for-byte; the envelope MUST match the Dart side exactly or
+ * Serverpod will reject the frame.
+ *
+ * Envelope shape: `{ "type": "<typeName>", "data": { ... } }`.
+ */
+
+export type WsMessageType =
+  | 'ping'
+  | 'pong'
+  | 'bad_request'
+  | 'open_method_stream_command'
+  | 'open_method_stream_response'
+  | 'close_method_stream_command'
+  | 'method_stream_message'
+  | 'method_stream_serializable_exception';
+
+export interface WsEnvelope<TData = unknown> {
+  type: WsMessageType;
+  data: TData;
+}
+
+export interface OpenMethodStreamCommandData {
+  endpoint: string;
+  method: string;
+  connectionId: string;
+  /** Double-encoded JSON string of the args map — matches Dart contract. */
+  args: string;
+  inputStreams: string[];
+  authentication?: string;
+}
+
+export type OpenMethodStreamResponseType =
+  | 'success'
+  | 'endpointNotFound'
+  | 'authenticationFailed'
+  | 'authorizationDeclined'
+  | 'invalidArguments';
+
+export interface OpenMethodStreamResponseData {
+  endpoint: string;
+  method: string;
+  connectionId: string;
+  responseType: OpenMethodStreamResponseType;
+}
+
+export interface CloseMethodStreamCommandData {
+  endpoint: string;
+  method: string;
+  connectionId: string;
+  parameter?: string;
+}
+
+export interface MethodStreamMessageData {
+  endpoint: string;
+  method: string;
+  connectionId: string;
+  /**
+   * If set, this message is an INPUT stream value the client is
+   * sending to the server. Omitted means it's an OUTPUT stream value
+   * the server sent to the client.
+   */
+  parameter?: string;
+  /** `{ className, data }` envelope per `wrapWithClassName` in Dart. */
+  object: { className: string; data: Record<string, unknown> };
+}
+
+export interface MethodStreamSerializableExceptionData {
+  endpoint: string;
+  method: string;
+  connectionId: string;
+  /** `{ className, data }` envelope of the typed exception. */
+  object: { className: string; data: Record<string, unknown> };
+}
+
+export interface BadRequestMessageData {
+  reason: string;
+}
+
+export function buildEnvelope<T>(type: WsMessageType, data: T): string {
+  return JSON.stringify({ type, data });
+}
+
+export function parseEnvelope(raw: string): WsEnvelope | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      typeof parsed.type !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as WsEnvelope;
+  } catch {
+    return null;
+  }
+}

--- a/lib/runtime/typescript/src/ws_transport.ts
+++ b/lib/runtime/typescript/src/ws_transport.ts
@@ -1,0 +1,266 @@
+import { ServerpodClientException } from './exceptions.js';
+import type { SerializationManager } from './serialization.js';
+import type { ClientAuthKeyProvider } from './types.js';
+import {
+  buildEnvelope,
+  parseEnvelope,
+  type CloseMethodStreamCommandData,
+  type MethodStreamMessageData,
+  type MethodStreamSerializableExceptionData,
+  type OpenMethodStreamCommandData,
+  type OpenMethodStreamResponseData,
+} from './ws_messages.js';
+
+/**
+ * Manages a single multiplexed WebSocket connection to
+ * `<host>/v1/websocket`. Generated client code calls
+ * `openOutputStream(...)` / `openBidiStream(...)` to start a
+ * server-side method that returns a `Stream<T>`.
+ *
+ * v0.1 supports server-to-client output streams. Bidirectional
+ * (client supplies input streams) is wired but minimally tested —
+ * follow-up issues track production hardening.
+ */
+export class ClientMethodStreamManager {
+  constructor(
+    private readonly host: string,
+    private readonly serializer: SerializationManager,
+    private readonly authProvider?: ClientAuthKeyProvider,
+  ) {}
+
+  private socket: WebSocket | undefined;
+  private socketReady: Promise<void> | undefined;
+  private nextConnectionId = 0;
+  private readonly handlers = new Map<string, _StreamHandler>();
+
+  async open(): Promise<void> {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) return;
+    if (this.socketReady) return this.socketReady;
+    this.socketReady = this._connect();
+    return this.socketReady;
+  }
+
+  private async _connect(): Promise<void> {
+    const url = await this._buildUrl();
+    const ws = new WebSocket(url);
+    this.socket = ws;
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true });
+      ws.addEventListener(
+        'error',
+        () => reject(new ServerpodClientException('WebSocket error', 0)),
+        { once: true },
+      );
+    });
+    ws.addEventListener('message', (e) => this._onMessage(String(e.data)));
+    ws.addEventListener('close', () => this._onClose());
+  }
+
+  private async _buildUrl(): Promise<string> {
+    const base = this.host.endsWith('/')
+      ? this.host.slice(0, -1)
+      : this.host;
+    let url = base.replace(/^http/, 'ws') + '/v1/websocket';
+    const auth = await this.authProvider?.getAuthHeaderValue();
+    if (auth) url += `?auth=${encodeURIComponent(auth)}`;
+    return url;
+  }
+
+  private _onMessage(raw: string): void {
+    const env = parseEnvelope(raw);
+    if (!env) return;
+    switch (env.type) {
+      case 'open_method_stream_response': {
+        const data = env.data as OpenMethodStreamResponseData;
+        this.handlers.get(data.connectionId)?.onOpenResponse(data);
+        return;
+      }
+      case 'method_stream_message': {
+        const data = env.data as MethodStreamMessageData;
+        this.handlers.get(data.connectionId)?.onValue(data);
+        return;
+      }
+      case 'method_stream_serializable_exception': {
+        const data = env.data as MethodStreamSerializableExceptionData;
+        this.handlers.get(data.connectionId)?.onException(data);
+        return;
+      }
+      case 'close_method_stream_command': {
+        const data = env.data as CloseMethodStreamCommandData;
+        this.handlers.get(data.connectionId)?.onClose();
+        return;
+      }
+      // ping/pong handled at the WebSocket layer; bad_request surfaces
+      // via the connection-level error path.
+      default:
+        return;
+    }
+  }
+
+  private _onClose(): void {
+    for (const h of this.handlers.values()) h.onClose();
+    this.handlers.clear();
+    this.socket = undefined;
+    this.socketReady = undefined;
+  }
+
+  /**
+   * Open an output-only stream and return an AsyncIterable that yields
+   * decoded values. Throws on auth/endpoint errors.
+   */
+  async openOutputStream<T>(opts: {
+    endpoint: string;
+    method: string;
+    args: Record<string, unknown>;
+    decode: (raw: unknown) => T;
+  }): Promise<AsyncIterable<T>> {
+    await this.open();
+    const connectionId = `c${this.nextConnectionId++}`;
+    const auth = await this.authProvider?.getAuthHeaderValue();
+    const command: OpenMethodStreamCommandData = {
+      endpoint: opts.endpoint,
+      method: opts.method,
+      connectionId,
+      // Double-encoded JSON string per Dart contract.
+      args: JSON.stringify(this._encodeArgs(opts.args)),
+      inputStreams: [],
+      ...(auth ? { authentication: auth } : {}),
+    };
+
+    const handler = new _StreamHandler(opts.decode, this.serializer);
+    this.handlers.set(connectionId, handler);
+    this.socket!.send(buildEnvelope('open_method_stream_command', command));
+    await handler.openResponse;
+
+    return handler.iterable<T>(() => {
+      const close: CloseMethodStreamCommandData = {
+        endpoint: opts.endpoint,
+        method: opts.method,
+        connectionId,
+      };
+      this.socket?.send(
+        buildEnvelope('close_method_stream_command', close),
+      );
+      this.handlers.delete(connectionId);
+    });
+  }
+
+  private _encodeArgs(
+    args: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args)) {
+      out[k] = this.serializer.encode(v);
+    }
+    return out;
+  }
+
+  /** Test/dispose hook. Closes the underlying WebSocket. */
+  close(): void {
+    this.socket?.close();
+    this.socket = undefined;
+    this.socketReady = undefined;
+    this.handlers.clear();
+  }
+}
+
+class _StreamHandler {
+  constructor(
+    private readonly decode: (raw: unknown) => unknown,
+    private readonly serializer: SerializationManager,
+  ) {}
+
+  private readonly _values: unknown[] = [];
+  private readonly _waiters: Array<(v: IteratorResult<unknown>) => void> = [];
+  private _error?: unknown;
+  private _closed = false;
+  private _openResolve?: () => void;
+  private _openReject?: (e: unknown) => void;
+
+  readonly openResponse: Promise<void> = new Promise((resolve, reject) => {
+    this._openResolve = resolve;
+    this._openReject = reject;
+  });
+
+  onOpenResponse(data: OpenMethodStreamResponseData): void {
+    if (data.responseType === 'success') {
+      this._openResolve?.();
+    } else {
+      this._openReject?.(
+        new ServerpodClientException(
+          `Failed to open stream: ${data.responseType}`,
+          0,
+        ),
+      );
+    }
+  }
+
+  onValue(data: MethodStreamMessageData): void {
+    if (this._closed) return;
+    const value = this.decode(data.object.data);
+    this._dispatch(value);
+  }
+
+  onException(data: MethodStreamSerializableExceptionData): void {
+    const err = this.serializer.deserializeByClassName(data.object);
+    this._error = err instanceof Error
+      ? err
+      : new ServerpodClientException(
+          `Stream exception: ${data.object.className}`,
+          0,
+        );
+    this._dispatchEnd();
+  }
+
+  onClose(): void {
+    if (this._closed) return;
+    this._closed = true;
+    this._dispatchEnd();
+  }
+
+  private _dispatch(value: unknown): void {
+    const waiter = this._waiters.shift();
+    if (waiter) {
+      waiter({ value, done: false });
+    } else {
+      this._values.push(value);
+    }
+  }
+
+  private _dispatchEnd(): void {
+    while (this._waiters.length > 0) {
+      this._waiters.shift()!({ value: undefined, done: true });
+    }
+  }
+
+  iterable<T>(onUserClose: () => void): AsyncIterable<T> {
+    const self = this;
+    return {
+      [Symbol.asyncIterator](): AsyncIterator<T> {
+        return {
+          next(): Promise<IteratorResult<T>> {
+            return new Promise<IteratorResult<unknown>>((resolve) => {
+              if (self._error) {
+                throw self._error;
+              }
+              if (self._values.length > 0) {
+                resolve({ value: self._values.shift(), done: false });
+                return;
+              }
+              if (self._closed) {
+                resolve({ value: undefined, done: true });
+                return;
+              }
+              self._waiters.push(resolve);
+            }) as Promise<IteratorResult<T>>;
+          },
+          async return(value): Promise<IteratorResult<T>> {
+            self._closed = true;
+            onUserClose();
+            return { value: value as T, done: true };
+          },
+        };
+      },
+    };
+  }
+}


### PR DESCRIPTION
Closes #10. Output-only `Stream<T>` endpoints now emit a real `callStreamingServerEndpoint` body returning `AsyncIterable<T>`. Bidirectional (input `Stream<T>` parameters) emits a clear "not supported in v0.1" stub — tracked as follow-up #25 with full design notes. Runtime adds ws_messages (envelope + double-encoded args contract per Serverpod) and ws_transport (ClientMethodStreamManager with auth, per-connection AsyncIterable handlers). 62/62 vitest passing, e2e tsc clean against the fixture's streaming endpoints.