### PR TITLE
fix(#19,#20,#21): fixture + analyzer + scaffold polish

### DIFF
--- a/lib/src/analyzer/protocol_loader.dart
+++ b/lib/src/analyzer/protocol_loader.dart
@@ -50,10 +50,17 @@ class ProtocolLoader {
   }
 
   static Future<GeneratorConfig> _loadConfig(Directory serverDirectory) async {
-    return GeneratorConfig.load(
-      serverRootDir: serverDirectory.path,
-      interactive: false,
-    );
+    try {
+      return await GeneratorConfig.load(
+        serverRootDir: serverDirectory.path,
+        interactive: false,
+      );
+    } catch (e) {
+      throw ProtocolLoaderException._(
+        ProtocolLoaderPhase.config,
+        'Failed to load GeneratorConfig from ${serverDirectory.path}: $e',
+      );
+    }
   }
 
   static Future<List<SerializableModelDefinition>> _runModelAnalysis(

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -89,8 +89,12 @@ class GenerateCommand extends Command<int> {
       return 70;
     }
 
+    // Tracker is scoped to ONLY generator-owned subdirectories so a
+    // user's hand-written `.ts` helper under `src/` never gets swept.
     final tracker = GeneratedFileTracker([
-      Directory(p.join(paths.outputDir.path, 'src')),
+      Directory(p.join(paths.outputDir.path, 'src', 'runtime')),
+      Directory(p.join(paths.outputDir.path, 'src', 'protocol')),
+      Directory(p.join(paths.outputDir.path, 'src', 'endpoints')),
     ]);
 
     final scaffold = ScaffoldEmitter(

--- a/lib/src/discovery/server_directory_finder.dart
+++ b/lib/src/discovery/server_directory_finder.dart
@@ -54,14 +54,22 @@ class ServerDirectoryFinder {
   }
 
   // Reads + parses pubspec.yaml at every directory the walk visits. On a
-  // deep path that's O(depth) syncronous reads; in practice always single
+  // deep path that's O(depth) synchronous reads; in practice always single
   // digits. If a future caller needs a faster walk (e.g. an LSP server
   // with many starts), extract a `PubspecPredicate` interface so a
   // pre-parsed pubspec can be passed in.
   static bool _isServerDirectory(Directory dir) {
     final pubspec = File(p.join(dir.path, 'pubspec.yaml'));
     if (!pubspec.existsSync()) return false;
-    final yaml = loadYaml(pubspec.readAsStringSync());
+    final dynamic yaml;
+    try {
+      yaml = loadYaml(pubspec.readAsStringSync());
+    } catch (_) {
+      // An invalid pubspec.yaml on the walk path means "not a Serverpod
+      // server" — keep walking. Don't let a malformed yaml in a parent
+      // directory blow up the whole search.
+      return false;
+    }
     if (yaml is! YamlMap) return false;
     if (yaml['name'] == 'serverpod') return true;
     final deps = yaml['dependencies'];

--- a/lib/src/emit/scaffold_emitter.dart
+++ b/lib/src/emit/scaffold_emitter.dart
@@ -74,7 +74,9 @@ class ScaffoldEmitter {
       final relativePath = p.relative(entity.path, from: runtimeSrc.path);
       final destFile = File(p.join(destDir.path, relativePath));
       destFile.parent.createSync(recursive: true);
-      destFile.writeAsStringSync(entity.readAsStringSync());
+      // Byte-level copy keeps the runtime truly verbatim — no BOM,
+      // line-ending, or encoding drift if the source file has them.
+      entity.copySync(destFile.path);
       tracker.recordWrite(destFile);
     }
   }

--- a/test/fixtures/sample_server/sample_server/pubspec.yaml
+++ b/test/fixtures/sample_server/sample_server/pubspec.yaml
@@ -18,18 +18,8 @@ dev_dependencies:
 
 serverpod:
   scripts:
-    # Starts the server and applies migrations
+    # Starts the server and applies migrations.
     start: dart bin/main.dart --apply-migrations
-
-    # Build the Flutter web app and copy it to the server's web directory.
-    # Windows uses xcopy since flutter's --output flag doesn't work there.
-    # See: https://github.com/flutter/flutter/issues/157886
-    flutter_build:
-      windows: >-
-        (if exist web\app rmdir /S /Q web\app)
-        & cd /D ..\sample_flutter
-        && flutter build web --base-href /app/ --wasm
-        && xcopy /E /I /Y build\web ..\sample_server\web\app
-      posix: |
-        cd ../sample_flutter
-        flutter build web --base-href /app/ --wasm --output ../sample_server/web/app
+    # The Flutter app was removed from this fixture (we don't need it
+    # for analyzer-driven tests). The default `flutter_build` script
+    # template is intentionally absent.

--- a/test/generate_command_test.dart
+++ b/test/generate_command_test.dart
@@ -61,7 +61,7 @@ void main() {
           'typescript',
           'node_modules',
           '.bin',
-          'tsc',
+          Platform.isWindows ? 'tsc.cmd' : 'tsc',
         ));
         if (!tscBinary.existsSync()) {
           printOnFailure(

--- a/test/module_emission_test.dart
+++ b/test/module_emission_test.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 /// Verifies that `generate` against a Serverpod *module* (`type: module`
-/// in generator.yaml) emits a `<Nickname>Caller extends
+/// in generator.yaml) emits a `[Nickname]Caller extends
 /// ModuleEndpointCaller` instead of a top-level `Client`.
 void main() {
   final packageRoot = Directory.current.path;

--- a/test/sample_server_fixture_test.dart
+++ b/test/sample_server_fixture_test.dart
@@ -61,7 +61,7 @@ void main() {
       final src = await _readServerFile('lib/src/endpoints/primitives_endpoint.dart');
       for (final type in const [
         'int', 'double', 'String', 'bool',
-        'DateTime', 'Duration', 'BigInt', 'UuidValue',
+        'DateTime', 'Duration', 'BigInt', 'UuidValue', 'ByteData',
       ]) {
         expect(src, contains(type), reason: 'expected primitive type: $type');
       }


### PR DESCRIPTION
Closes #19, #20, #21. Bundles the small follow-ups from PRs #12/#13/#14 review feedback. ByteData smoke-test coverage, dropped flutter_build script, typed ProtocolLoaderException(phase=config), YAML-parse robustness in the directory walker, byte-level runtime copy, scoped GeneratedFileTracker, Windows tsc.cmd. 77/77 tests passing.