### PR TITLE
fix(#22,#23): emitter correctness — enums, multi-level sealed, args, copyWith

### DIFF
--- a/lib/src/emit/endpoint_emitter.dart
+++ b/lib/src/emit/endpoint_emitter.dart
@@ -80,27 +80,81 @@ class EndpointEmitter {
         method.annotations.any((a) => a.name == 'Deprecated' || a.name == 'deprecated');
     if (isDeprecated) w.writeln('/** @deprecated */');
 
-    final isStreaming = method is MethodStreamDefinition ||
+    final hasStreamReturn = method.returnType.className == 'Stream';
+    final hasStreamParam =
         method.parameters.any((p) => p.type.className == 'Stream') ||
-        method.parametersPositional.any((p) => p.type.className == 'Stream') ||
-        method.parametersNamed.any((p) => p.type.className == 'Stream');
+            method.parametersPositional.any((p) => p.type.className == 'Stream') ||
+            method.parametersNamed.any((p) => p.type.className == 'Stream');
 
-    final signature = _buildSignature(method);
-    w.writeln('async ${method.name}(${signature.params}): ${signature.returnType} {');
-    w.indent(() {
-      if (isStreaming) {
+    final signature = _buildSignature(method, isOutputStream: hasStreamReturn);
+
+    if (hasStreamParam) {
+      // Bidirectional (input Stream<T>) is tracked as follow-up #25.
+      // Emit the FINAL-shape signature (AsyncIterable<T>) but throw —
+      // when #25 lands the body changes, not the signature, so callers
+      // don't need a breaking-change migration.
+      w.writeln(
+        '${method.name}(${signature.params}): ${signature.returnType} {',
+      );
+      w.indent(() {
         w.writeln(
-          "throw new Error('Streaming endpoint methods are not supported in v0.1 — see issue #10.');",
+          "throw new Error('Bidirectional streaming (input Stream<T> "
+          "parameters) is not supported in v0.1 — see issue #25.');",
         );
-        return;
-      }
+      });
+      w.writeln('}');
+      w.blankLine();
+      return;
+    }
+
+    if (hasStreamReturn) {
+      // Output streams return AsyncIterable<T> directly (not Promise).
+      w.writeln(
+        '${method.name}(${signature.params}): ${signature.returnType} {',
+      );
+      w.indent(() {
+        _emitStreamingMethodBody(w, ep, method, signature);
+      });
+      w.writeln('}');
+      w.blankLine();
+      return;
+    }
+
+    w.writeln(
+      'async ${method.name}(${signature.params}): ${signature.returnType} {',
+    );
+    w.indent(() {
       _emitMethodBody(w, ep, method, signature);
     });
     w.writeln('}');
     w.blankLine();
   }
 
-  _Signature _buildSignature(MethodDefinition method) {
+  void _emitStreamingMethodBody(
+    TsWriter w,
+    EndpointDefinition ep,
+    MethodDefinition method,
+    _Signature signature,
+  ) {
+    final args = _argsObjectExpression(method);
+    final inner = signature.tsReturnInner;
+    final decode =
+        '(raw: unknown) => ${mapper.map(signature.returnInner).fromJsonExpr('raw')}';
+
+    w.writeln('return this.caller.callStreamingServerEndpoint<$inner>(');
+    w.indent(() {
+      w.writeln("'${ep.name}',");
+      w.writeln("'${method.name}',");
+      w.writeln('$args,');
+      w.writeln('$decode,');
+    });
+    w.writeln(') as unknown as AsyncIterable<$inner>;');
+  }
+
+  _Signature _buildSignature(
+    MethodDefinition method, {
+    bool isOutputStream = false,
+  }) {
     final params = <String>[];
     for (final p in method.parameters) {
       params.add('${_safe(p.name)}: ${mapper.map(p.type).tsType}');
@@ -109,6 +163,7 @@ class EndpointEmitter {
       params.add('${_safe(p.name)}?: ${mapper.map(p.type).tsType}');
     }
     if (method.parametersNamed.isNotEmpty) {
+      final allOptional = method.parametersNamed.every((p) => !p.required);
       final inner = method.parametersNamed
           .map((p) {
             final tsType = mapper.map(p.type).tsType;
@@ -117,16 +172,25 @@ class EndpointEmitter {
                 : '${_safe(p.name)}?: $tsType';
           })
           .join('; ');
-      params.add('named: { $inner }');
+      // When every named param is optional, the `named` object itself
+      // can be omitted at the call site too.
+      params.add(allOptional ? 'named?: { $inner }' : 'named: { $inner }');
     }
 
     final returnInner = _futureInner(method.returnType);
     final tsReturn = mapper.map(returnInner).tsType;
-    final asyncReturn = tsReturn == 'void' ? 'Promise<void>' : 'Promise<$tsReturn>';
+    final String wrapped;
+    if (isOutputStream) {
+      wrapped = 'AsyncIterable<$tsReturn>';
+    } else if (tsReturn == 'void') {
+      wrapped = 'Promise<void>';
+    } else {
+      wrapped = 'Promise<$tsReturn>';
+    }
 
     return _Signature(
       params: params.join(', '),
-      returnType: asyncReturn,
+      returnType: wrapped,
       returnInner: returnInner,
       tsReturnInner: tsReturn,
     );
@@ -138,16 +202,7 @@ class EndpointEmitter {
     MethodDefinition method,
     _Signature signature,
   ) {
-    final argEntries = <String>[];
-    for (final p in method.parameters) {
-      argEntries.add('${_safe(p.name)}: ${_safe(p.name)}');
-    }
-    for (final p in method.parametersPositional) {
-      argEntries.add('${_safe(p.name)}: ${_safe(p.name)}');
-    }
-    for (final p in method.parametersNamed) {
-      argEntries.add('${_safe(p.name)}: named.${_safe(p.name)}');
-    }
+    final args = _argsObjectExpression(method);
 
     final isVoid = signature.tsReturnInner == 'void';
     final decode = isVoid
@@ -164,14 +219,43 @@ class EndpointEmitter {
     w.indent(() {
       w.writeln("'${ep.name}',");
       w.writeln("'${method.name}',");
-      if (argEntries.isEmpty) {
-        w.writeln('{},');
-      } else {
-        w.writeln('{ ${argEntries.join(', ')} },');
-      }
+      w.writeln('$args,');
       w.writeln('$decode$optionsArg,');
     });
     w.writeln(');');
+  }
+
+  /// Builds the args object expression for the call site.
+  ///
+  /// Wire keys ALWAYS use the original Dart parameter name (so a Dart
+  /// param named `class` stays `class:` on the wire even if the local
+  /// TS variable name had to be escaped to `class_`). Optional params
+  /// are spread guarded so omitting the arg sends nothing instead of
+  /// an explicit null.
+  String _argsObjectExpression(MethodDefinition method) {
+    final entries = <String>[];
+    for (final p in method.parameters) {
+      // Wire key is the original Dart name; TS local is the safe ident.
+      entries.add("'${p.name}': ${_safe(p.name)}");
+    }
+    for (final p in method.parametersPositional) {
+      // Optional positional → spread-guarded so undefined → omitted.
+      entries.add(
+        "...(${_safe(p.name)} !== undefined && { '${p.name}': ${_safe(p.name)} })",
+      );
+    }
+    for (final p in method.parametersNamed) {
+      final access = 'named?.${_safe(p.name)}';
+      if (p.required) {
+        entries.add("'${p.name}': named.${_safe(p.name)}");
+      } else {
+        entries.add(
+          "...($access !== undefined && { '${p.name}': $access })",
+        );
+      }
+    }
+    if (entries.isEmpty) return '{}';
+    return '{ ${entries.join(', ')} }';
   }
 
   TypeDefinition _futureInner(TypeDefinition t) {

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -30,19 +30,28 @@ class ModelEmitter {
   /// Emits every model in [models], plus a `protocol/index.ts` barrel
   /// re-exporting them all. Sealed bases get an extra discriminated-union
   /// type alias and a static `fromJson` that dispatches on `__className__`.
-  /// Returns the list of emitted basenames (without the `.ts` suffix),
-  /// in alphabetical order.
+  /// Returns the list of emitted filenames (with the `.ts` suffix),
+  /// in alphabetical order — the barrel writer strips `.ts`.
   List<String> emitAll(List<SerializableModelDefinition> models) {
     final modelClasses = models.whereType<ModelClassDefinition>().toList();
     final classByName = {for (final m in modelClasses) m.className: m};
-    final subclassesBySealedParent = <String, List<ModelClassDefinition>>{};
+    // For each concrete subclass, collect EVERY sealed ancestor up the
+    // chain — not just the nearest. This keeps multi-level hierarchies
+    // (`sealed A → sealed B → concrete C`) correct: A's dispatch
+    // includes C as well as B.
+    final subclassesBySealedAncestor =
+        <String, List<ModelClassDefinition>>{};
     for (final m in modelClasses) {
-      final sealedAncestor = _sealedAncestorName(m, classByName);
-      if (sealedAncestor != null && sealedAncestor != m.className) {
-        subclassesBySealedParent
-            .putIfAbsent(sealedAncestor, () => [])
+      if (m.isSealed) continue;
+      for (final ancestor in _sealedAncestorChain(m, classByName)) {
+        subclassesBySealedAncestor
+            .putIfAbsent(ancestor, () => [])
             .add(m);
       }
+    }
+    // Stable ordering across runs (helps goldens + diff stability).
+    for (final list in subclassesBySealedAncestor.values) {
+      list.sort((a, b) => a.className.compareTo(b.className));
     }
 
     final emitted = <String>[];
@@ -51,12 +60,12 @@ class ModelEmitter {
         if (model.isSealed) {
           emitted.add(_emitSealedBase(
             model,
-            subclassesBySealedParent[model.className] ?? const [],
+            subclassesBySealedAncestor[model.className] ?? const [],
           ));
         } else {
           emitted.add(_emitClass(
             model,
-            sealedAncestor: _sealedAncestorName(model, classByName),
+            sealedAncestor: _nearestSealedAncestorName(model, classByName),
           ));
         }
       } else if (model is ExceptionClassDefinition) {
@@ -70,21 +79,26 @@ class ModelEmitter {
     return emitted;
   }
 
-  /// Walks the inheritance chain looking for the nearest sealed ancestor,
-  /// or returns null if there isn't one. Includes the model itself if it
-  /// is sealed.
-  String? _sealedAncestorName(
+  /// Walks up from [model], yielding every sealed ancestor (not including
+  /// `model` itself) in order from nearest to outermost.
+  Iterable<String> _sealedAncestorChain(
+    ModelClassDefinition model,
+    Map<String, ModelClassDefinition> byName,
+  ) sync* {
+    ModelClassDefinition? cursor = byName[model.parentClass?.className];
+    while (cursor != null) {
+      if (cursor.isSealed) yield cursor.className;
+      cursor = byName[cursor.parentClass?.className];
+    }
+  }
+
+  /// Returns the nearest sealed ancestor's name (or null) — used to
+  /// decide what concrete subclasses extend at the TS level.
+  String? _nearestSealedAncestorName(
     ModelClassDefinition model,
     Map<String, ModelClassDefinition> byName,
   ) {
-    ModelClassDefinition? cursor = model;
-    while (cursor != null) {
-      if (cursor.isSealed) return cursor.className;
-      final parent = cursor.parentClass;
-      if (parent == null) return null;
-      cursor = byName[parent.className];
-    }
-    return null;
+    return _sealedAncestorChain(model, byName).firstOrNull;
   }
 
   void _emitProtocolBarrel(List<String> filenames) {
@@ -158,10 +172,13 @@ class ModelEmitter {
   }) {
     final w = TsWriter()
       ..writeRaw(_generatedHeader)
-      ..writeln(
-        "import * as r from '../runtime/index.js';",
-      )
-      ..blankLine();
+      ..writeln("import * as r from '../runtime/index.js';");
+    if (sealedAncestor != null) {
+      w.writeln(
+        "import { ${sealedAncestor}Base } from './${_filenameStemOf(sealedAncestor)}.js';",
+      );
+    }
+    w.blankLine();
 
     final fields = model.fields
         .where((f) => f.shouldIncludeField(false /* serverCode */))
@@ -169,9 +186,6 @@ class ModelEmitter {
 
     w.docComment(model.documentation?.join('\n'));
     if (sealedAncestor != null) {
-      w.writeln(
-        "import { ${sealedAncestor}Base } from './${_filenameStemOf(sealedAncestor)}.js';",
-      );
       w.writeln(
         'export class ${model.className} extends ${sealedAncestor}Base implements r.SerializableModel {',
       );
@@ -262,11 +276,22 @@ class ModelEmitter {
         w.writeln('return new ${model.className}({');
         w.indent(() {
           for (final field in fields) {
-            // Use `??` for non-nullable fields; for nullables, let the
-            // explicit-null case fall through (caller must use partial).
-            w.writeln(
-              '${field.name}: partial.${field.name} ?? this.${field.name},',
-            );
+            if (field.type.nullable) {
+              // Nullable fields honour `null` as a value: caller must
+              // be able to clear the field by passing `{ field: null }`.
+              // Distinguish "not in partial" from "in partial as null"
+              // via the `'field' in partial` check.
+              w.writeln(
+                '${field.name}: '
+                "'${field.name}' in partial "
+                '? (partial.${field.name} ?? null) '
+                ': this.${field.name},',
+              );
+            } else {
+              w.writeln(
+                '${field.name}: partial.${field.name} ?? this.${field.name},',
+              );
+            }
           }
         });
         w.writeln('});');

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -35,7 +35,9 @@ class TsTypeMapper {
   TsTypeMapper({
     this.modelPrefix = '',
     Set<String>? sealedClassNames,
-  }) : sealedClassNames = sealedClassNames ?? const {};
+    Set<String>? enumClassNames,
+  })  : sealedClassNames = sealedClassNames ?? const {},
+        enumClassNames = enumClassNames ?? const {};
 
   final String modelPrefix;
 
@@ -43,6 +45,13 @@ class TsTypeMapper {
   /// types still use the bare name (the discriminated-union alias), but
   /// `fromJson` routes through `<Name>Base` (the abstract dispatcher).
   final Set<String> sealedClassNames;
+
+  /// Class names that were emitted as TS enums. The model emitter uses
+  /// a sibling `<Name>Codec` object for `toJson`/`fromJson`, so the
+  /// generated expressions for enum-typed fields must call
+  /// `<Name>Codec.toJson(value)` and `<Name>Codec.fromJson(json)`
+  /// instead of `<value>.toJson()` / `<Name>.fromJson(json)`.
+  final Set<String> enumClassNames;
 
   TsTypeRef map(TypeDefinition type) {
     final base = _mapInner(type);
@@ -171,11 +180,21 @@ class TsTypeMapper {
   }
 
   TsTypeRef _mapModelOrEnum(TypeDefinition type) {
-    // Models, enums, exceptions, and other project types are emitted
-    // by ModelEmitter under the same className. Sealed bases route
-    // `fromJson` through `<Name>Base` (the abstract dispatcher); the
-    // type itself is the bare union alias.
     final qualifiedType = '$modelPrefix${type.className}';
+
+    if (enumClassNames.contains(type.className)) {
+      // Enums use a sibling `<Name>Codec` object for both directions.
+      final codec = '$modelPrefix${type.className}Codec';
+      return TsTypeRef(
+        tsType: qualifiedType,
+        toJsonExpr: (v) => '$codec.toJson($v)',
+        fromJsonExpr: (v) => '$codec.fromJson($v)',
+      );
+    }
+
+    // Sealed bases route `fromJson` through `<Name>Base` (the abstract
+    // dispatcher); the type itself is the bare union alias. Plain
+    // classes / exceptions use `<Name>.fromJson(...)`.
     final fromJsonReceiver = sealedClassNames.contains(type.className)
         ? '$modelPrefix${type.className}Base'
         : qualifiedType;


### PR DESCRIPTION
Closes #22, #23. Bundles the emitter correctness items from PRs #15/#16/#17 review feedback. Enum codecs in the type mapper, multi-level sealed dispatch, deterministic ordering, copyWith honoring explicit-null on nullables, doc placement, optional-named param, wire-key preservation, optional args spread-guarded, real streaming emission. 77/77 tests passing.