### PR TITLE
feat(#11): release polish — README, CONTRIBUTING, CHANGELOG, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  dart:
+    name: Dart suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.11.4
+
+      - name: Pub get (host package)
+        run: dart pub get
+
+      - name: Pub get (sample_server fixture workspace)
+        run: dart pub get
+        working-directory: test/fixtures/sample_server
+
+      - name: Pub get (sample_module fixture workspace)
+        run: dart pub get
+        working-directory: test/fixtures/sample_module
+
+      - name: Setup Node (for the runtime npm install needed by the e2e tsc check)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: npm install (TypeScript runtime)
+        run: npm install
+        working-directory: lib/runtime/typescript
+
+      - name: dart analyze
+        run: dart analyze
+
+      - name: dart test
+        run: dart test --reporter expanded
+
+  typescript:
+    name: TypeScript runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: lib/runtime/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm run typecheck
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,60 @@
 ## 0.1.0
 
-- Initial scaffold. No public API yet.
+First usable release. Generates a `tsc --noEmit` clean TypeScript client
+for a Serverpod project, matching the Dart client's wire format
+byte-for-byte.
+
+### Generator
+- `dart run serverpod_typescript_bridge generate` produces
+  `<server>/../<name>_typescript_client/` (overridable via `--output`
+  or `typescript_client_package_path:` in `config/generator.yaml`).
+- `dart run serverpod_typescript_bridge inspect` dumps the parsed
+  IR as JSON for debugging.
+- Project discovery walks up from cwd; honours `--directory`.
+- Reuses `serverpod_cli`'s public analyzer so every feature Serverpod
+  understands flows through automatically.
+
+### Generated TS client
+- One TS class per Serverpod model (`fromJson` / `toJson` / `copyWith`).
+- Sealed hierarchies emit a discriminated-union type alias plus an
+  abstract `<Name>Base.fromJson` dispatcher; multi-level sealed
+  hierarchies dispatch correctly through every ancestor.
+- Enums emit a TS `enum` plus a sibling `<Name>Codec` for both
+  `byIndex` and `byName` serialisation.
+- Exceptions extend `Error` and round-trip via `Protocol`.
+- One TS class per endpoint with one async method per server method.
+  Required/optional positional/named parameters all supported;
+  optional params are spread-guarded so omitted args become omitted
+  keys (not explicit `null`s). `@unauthenticatedClientCall` and
+  `@Deprecated` propagate.
+- Top-level `Client extends ServerpodClientShared` with one field
+  per top-level endpoint; project `Protocol extends
+  SerializationManager` with the per-class deserialise switch.
+- Module-type projects emit a `<Nickname>Caller extends
+  ModuleEndpointCaller` plus a `modulePrefix` const; the Protocol
+  switch normalises module-prefixed `__className__` values.
+
+### Runtime (vendored under `src/runtime/`)
+- HTTP unary calls via `fetch`. Status mapping (400/401/403/404/500),
+  one-shot 401 refresh for `RefreshableClientAuthKeyProvider`, typed
+  exception decoding via `Protocol.deserializeByClassName`.
+- WebSocket transport (`<host>/v1/websocket`) for output streams.
+  Generated streaming methods return `AsyncIterable<T>`.
+- All wire-format converters match `serverpod_serialization`
+  byte-for-byte: ISO-8601 UTC for DateTime, integer ms for Duration,
+  string for BigInt, base64 for ByteData, list for Set, list of
+  `{k,v}` for non-string-keyed Maps.
+
+### Tests
+- 77+ Dart cases (analyzer integration, emitters, e2e via spawned
+  CLI + `tsc --noEmit`).
+- 60+ vitest cases for the runtime (every primitive converter, every
+  HTTP status mapping, auth-refresh single-retry, WS envelope
+  round-trip).
+
+### Known limitations (deferred)
+- Bidirectional streaming (input `Stream<T>` parameters) — generated
+  body throws; tracked at #25.
+- Records (Dart 3) — not supported.
+- Watch mode (`-w`) — not supported.
+- npm-published runtime — vendored for now; v0.2 will publish.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to serverpod_typescript_bridge
+
+## Local setup
+
+```bash
+git clone https://github.com/ChristopherLinnett/serverpod_typescript_bridge
+cd serverpod_typescript_bridge
+dart pub get
+
+# install the vendored TypeScript runtime's deps (vitest, tsc)
+cd lib/runtime/typescript && npm install && cd -
+```
+
+## Running the test suites
+
+The project has two test layers — a Dart suite (generator + analyzer + e2e) and a TypeScript suite (runtime).
+
+```bash
+# Dart side: 77+ cases incl. e2e against both fixtures
+dart analyze
+dart test
+
+# TypeScript runtime side: 60+ vitest cases
+cd lib/runtime/typescript
+npm run typecheck
+npm test
+```
+
+Both layers must pass before opening a PR.
+
+## Adding a new fixture case
+
+The two fixtures live under `test/fixtures/`:
+
+- **`sample_server/`** — the v0.1 parity oracle: a server-type Serverpod project covering every supported feature.
+- **`sample_module/`** — a minimal module-type Serverpod project.
+
+To add a new feature surface (e.g. exercising a new wire-format edge case):
+
+1. Add or edit the relevant `.dart` endpoint or `.spy.yaml` model under `test/fixtures/sample_server/sample_server/lib/src/{endpoints,models}/`.
+2. Regenerate Serverpod's own server + Dart-client output:
+   ```bash
+   cd test/fixtures/sample_server
+   dart pub get
+   cd sample_server
+   serverpod generate
+   ```
+3. Commit the fixture changes alongside the regenerated `lib/src/generated/` and `../sample_client/lib/src/protocol/` files.
+4. Update the smoke test (`test/sample_server_fixture_test.dart`) so the new surface is asserted.
+
+## Running the integration tests locally
+
+The `test/generate_command_test.dart` and `test/module_emission_test.dart` end-to-end tests:
+
+1. Spawn the CLI as a subprocess against the relevant fixture
+2. Type-check the generated TypeScript with the runtime's local `tsc`
+
+Both rely on the runtime's `node_modules` having been installed (see the local-setup step above). Without it, the tsc step is silently skipped.
+
+## Coding conventions
+
+- Match the existing emitter style: indent-aware writer, no string-templating libraries.
+- Comments explain *why*, never *what*.
+- Don't write multi-paragraph docstrings — one short line max.
+- Tests cover real scenarios, not implementation details. Prefer integration tests against the fixture over mock-heavy unit tests.
+
+## Release procedure (maintainer)
+
+1. Bump `version:` in `pubspec.yaml`.
+2. Update `CHANGELOG.md`.
+3. Verify the full suite is green: `dart analyze && dart test && (cd lib/runtime/typescript && npm test)`.
+4. Run the external smoke-test: generate against a non-fixture Serverpod project (e.g. a fresh `serverpod create -t mini -n smoke` outside this repo) and verify the output is `tsc --noEmit` clean.
+5. Commit + tag: `git tag v<version> && git push --tags`.
+6. (Optional, deferred to v0.2) `dart pub publish` once stabilised.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,111 @@
 # serverpod_typescript_bridge
 
-Generate a fully-typed TypeScript client for a Serverpod project — the same way `serverpod generate` produces the Dart client today.
+Generate a fully-typed TypeScript client for a Serverpod project — drop-in parity with `serverpod generate` for the Dart client.
 
 ## Status
 
-**Pre-alpha.** Under active construction. Not usable yet.
+**v0.1 — usable.** The generator produces a tsc-clean, type-safe TypeScript client for any Serverpod project against the surface listed below. See the support matrix for known limitations.
 
-## What it will do
-
-Given a Serverpod project, this package generates a sibling package
-`<project_name>_typescript_client` containing:
-
-- A typed TypeScript client for every endpoint
-- TypeScript classes for every Serverpod model (with all primitive and complex
-  type conversions handled)
-- All Dart doc comments preserved as TSDoc
-- A build-ready package (`tsconfig.json`, `package.json`, compiled `dist/`) so
-  it can be consumed by any TypeScript/JavaScript frontend (React, Vue, etc.)
-
-## Goals
-
-- **Drop-in parity** with `serverpod generate` for the Dart client. Same options, same workflow.
-- **No re-definition.** Endpoints, models, and docs come straight from the Serverpod project.
-- **Type-safe end-to-end.** All Dart primitives map to ergonomic TypeScript primitives.
-- **Zero runtime divergence.** The generated client uses the same wire protocol as the Dart client.
-
-## Usage (planned)
+## Quick start
 
 ```bash
-# inside a Serverpod project
+# inside your Serverpod server package
 dart pub add --dev serverpod_typescript_bridge
+
+# generate the TS client
 dart run serverpod_typescript_bridge generate
 ```
 
-This produces `<project_name>_typescript_client/` next to your existing
-`<project_name>_client/` Dart package.
+This writes a sibling package to your existing Dart client:
+
+```
+my_app/
+├── my_app_server/                   # your Serverpod server package
+├── my_app_client/                   # serverpod-generated Dart client
+└── my_app_typescript_client/        # serverpod_typescript_bridge output
+    ├── package.json
+    ├── tsconfig.json
+    └── src/
+        ├── client.ts                # top-level Client
+        ├── protocol.ts              # SerializationManager + dispatch
+        ├── runtime/                 # vendored runtime (HTTP + WS)
+        ├── protocol/                # one TS class per model
+        └── endpoints/               # one TS class per endpoint
+```
+
+Then in your TS/React app:
+
+```ts
+import { Client } from 'my_app_typescript_client';
+
+const client = new Client('https://api.my-app.com');
+const greeting = await client.greeting.sayHello('world');
+```
+
+## Supported in v0.1
+
+| Feature | Status | Notes |
+|---|---|---|
+| Endpoint methods (unary HTTP) | ✅ | required/optional positional + named params |
+| Doc-comment passthrough | ✅ | Dart `///` and `{@template}`/`{@macro}` → TSDoc |
+| `@unauthenticatedClientCall` | ✅ | flips `authenticated: false` per call |
+| `@Deprecated` | ✅ | propagates to JSDoc `@deprecated` |
+| Primitives | ✅ | int, double, String, bool, DateTime, Duration, BigInt, UuidValue, ByteData |
+| Collections | ✅ | `List<T>`, `Set<T>`, `Map<String,V>`, `Map<K,V>` (non-string-keyed wire form) |
+| Nullables | ✅ | `T?` → `T \| null`; `copyWith` honours explicit `null` |
+| Sealed hierarchies | ✅ | discriminated-union TS type + `<Name>Base.fromJson` dispatch on `__className__` |
+| Multi-level sealed | ✅ | every concrete subclass dispatches through every sealed ancestor |
+| Enums | ✅ | both `byIndex` and `byName` |
+| Exceptions | ✅ | `SerializableException` subclasses extend `Error` and round-trip via `Protocol` |
+| Modules (`type: module`) | ✅ | emits `<Nickname>Caller extends ModuleEndpointCaller` + `modulePrefix` const |
+| Module-prefix `__className__` | ✅ | Protocol switch normalises `<prefix>.<Class>` → bare `<Class>` |
+| HTTP unary calls | ✅ | fetch-based; status mapping; auth header; one-shot 401 refresh |
+| Output streams | ✅ | `Stream<T>` returns → `AsyncIterable<T>`; WebSocket transport |
+| Typed exceptions | ✅ | `{className, data}` envelope decoded via `Protocol.deserializeByClassName` |
+
+## Out of scope for v0.1
+
+| Feature | Tracker |
+|---|---|
+| Bidirectional streaming (input `Stream<T>` parameters) | [#25](https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues/25) |
+| Records (Dart 3 records as endpoint params/return) | post-v0.1 |
+| Watch mode (`-w`) | post-v0.1 |
+| Module client npm publishing (currently vendored) | v0.2 |
+| `dart run serverpod_typescript_bridge inspect` polish | works, but undocumented; primarily a debug surface |
+
+## CLI reference
+
+```
+$ dart run serverpod_typescript_bridge --help
+
+Generate a TypeScript client for a Serverpod project.
+
+Usage: serverpod_typescript_bridge <command> [arguments]
+
+Commands:
+  generate   Generate the TypeScript client package next to the Serverpod project.
+  inspect    Print the parsed protocol IR as JSON (for debugging).
+
+Options:
+  -d, --directory   Path to the Serverpod server package (auto-detected if omitted).
+  -o, --output      Path to the TypeScript client package to (re-)generate.
+                    Defaults to <server>/../<name>_typescript_client/.
+                    Override via `typescript_client_package_path` in
+                    `config/generator.yaml`.
+```
+
+## How it works
+
+The generator is a Dart-side tool that reuses **`serverpod_cli`'s public analyzer** to load the IR for your Serverpod project, then walks that IR and emits TypeScript. Because the IR is the same one Serverpod uses internally, there's no parser drift — every feature Serverpod knows about flows through automatically.
+
+The generated client depends on a small TypeScript runtime that ships *vendored* inside each generated package (under `src/runtime/`). v0.2 will publish the runtime to npm and switch generated packages to declare it as a dependency; existing v0.1 clients re-generate cleanly into v0.2.
+
+For the full architecture, see [docs/architecture.md](docs/architecture.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-TBD.
+[MIT](LICENSE).


### PR DESCRIPTION
Closes #11. README rewritten as a v0.1-usable doc with feature matrix + deferred-feature table; CONTRIBUTING covers local setup + maintainer release flow; CHANGELOG fills out the v0.1.0 surface; CI workflow runs dart + typescript suites on push/PR. External smoke-test verified by generating against a fresh `serverpod create -t mini -n smoke` outside the repo (tsc --noEmit clean).