### PR TITLE
fix(#23): convert decodeRecord doc to TSDoc

### DIFF
--- a/lib/runtime/typescript/src/serialization.ts
+++ b/lib/runtime/typescript/src/serialization.ts
@@ -157,9 +157,11 @@ export function encodeMap<K, V>(
   return out;
 }
 
-/// String-keyed sibling of [decodeMap] that returns a plain
-/// JavaScript object — generated client code for `Map<String, V>`
-/// uses this to keep the ergonomic `Record<string, V>` TS type.
+/**
+ * String-keyed sibling of {@link decodeMap} that returns a plain
+ * JavaScript object — generated client code for `Map<String, V>`
+ * uses this to keep the ergonomic `Record<string, V>` TS type.
+ */
 export function decodeRecord<V>(
   json: unknown,
   valueDecoder: (raw: unknown) => V,


### PR DESCRIPTION
Closes #23. Last remaining item from the #23 follow-up — Dart-style `///` doc comment converted to TSDoc with `{@link decodeMap}`. The fix was claimed in PR #28 but didn't actually land in the merged code.