### PR TITLE
fix: cross-file imports for model field references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.1.3
+
+- Bugfix: model emitter now emits cross-file imports for fields whose
+  type references other project models. Previously a `field: SomeOther`
+  would compile only if every file happened to be in the same scope —
+  for any non-trivial Serverpod project the generated `tsc --noEmit`
+  reported `TS2304: Cannot find name 'SomeOther'`. Each model file now
+  walks its field types (descending into generics like `List<T>` /
+  `Map<K, V>`) and emits one `import { Name<, NameBase>?<, NameCodec>? }
+  from './<snake>.js';` per referenced project type. Self-references
+  are skipped.
+- Fixture's `UserProfile` extended with cross-references to `Priority`
+  (enum), `Colour` (enum, byName), `Animal` (sealed), and
+  `List<Priority>` (collection-wrapped enum) so the e2e regression-tests
+  this path going forward.
+
 ## 0.1.2
 
 - `generate` now runs `npm install` + `npm run build` in the output

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -14,8 +14,7 @@ const _generatedHeader = '''
 ''';
 
 /// Emits one TypeScript file per Serverpod model — class, enum, or
-/// exception. Sealed hierarchies are out of scope for this pass; that
-/// emitter is added in issue #6.
+/// exception — plus a `protocol/index.ts` barrel re-exporting them.
 class ModelEmitter {
   ModelEmitter({
     required this.outputDir,
@@ -27,18 +26,30 @@ class ModelEmitter {
   final GeneratedFileTracker tracker;
   final TsTypeMapper mapper;
 
+  /// Class names emitted as TS enums. Used for cross-file imports —
+  /// enum imports also need to bring in `<Name>Codec`.
+  Set<String> get _enumClassNames => mapper.enumClassNames;
+
+  /// Class names emitted as sealed bases. Cross-file imports must also
+  /// bring in `<Name>Base` (the dispatcher) when a field references the
+  /// sealed type.
+  Set<String> get _sealedClassNames => mapper.sealedClassNames;
+
+  /// Every class name in the project — sealed bases, plain classes,
+  /// exceptions, and enums. Populated by [emitAll] before any per-file
+  /// emission so cross-file imports can be resolved.
+  late Set<String> _allClassNames;
+
   /// Emits every model in [models], plus a `protocol/index.ts` barrel
   /// re-exporting them all. Sealed bases get an extra discriminated-union
   /// type alias and a static `fromJson` that dispatches on `__className__`.
   /// Returns the list of emitted filenames (with the `.ts` suffix),
   /// in alphabetical order — the barrel writer strips `.ts`.
   List<String> emitAll(List<SerializableModelDefinition> models) {
+    _allClassNames = {for (final m in models) m.className};
+
     final modelClasses = models.whereType<ModelClassDefinition>().toList();
     final classByName = {for (final m in modelClasses) m.className: m};
-    // For each concrete subclass, collect EVERY sealed ancestor up the
-    // chain — not just the nearest. This keeps multi-level hierarchies
-    // (`sealed A → sealed B → concrete C`) correct: A's dispatch
-    // includes C as well as B.
     final subclassesBySealedAncestor =
         <String, List<ModelClassDefinition>>{};
     for (final m in modelClasses) {
@@ -49,7 +60,6 @@ class ModelEmitter {
             .add(m);
       }
     }
-    // Stable ordering across runs (helps goldens + diff stability).
     for (final list in subclassesBySealedAncestor.values) {
       list.sort((a, b) => a.className.compareTo(b.className));
     }
@@ -92,8 +102,6 @@ class ModelEmitter {
     }
   }
 
-  /// Returns the nearest sealed ancestor's name (or null) — used to
-  /// decide what concrete subclasses extend at the TS level.
   String? _nearestSealedAncestorName(
     ModelClassDefinition model,
     Map<String, ModelClassDefinition> byName,
@@ -110,6 +118,63 @@ class ModelEmitter {
     _writeFile('index.ts', w.toString());
   }
 
+  /// Walks a [TypeDefinition] recursively (descending into generics)
+  /// and yields every project-class name referenced. Skips primitives,
+  /// collections (List/Set/Map/Future/Stream), and any self-reference.
+  void _collectReferencedProjectTypes(
+    TypeDefinition type,
+    Set<String> out,
+  ) {
+    final name = type.className;
+    if (_allClassNames.contains(name)) out.add(name);
+    for (final g in type.generics) {
+      _collectReferencedProjectTypes(g, out);
+    }
+  }
+
+  /// Builds the cross-file import lines for [ownClassName], based on
+  /// the project types referenced in [fields] (plus an optional
+  /// extra symbol like a sealed ancestor we always need to import).
+  ///
+  /// Each emitted line covers ONE other file in `protocol/` and
+  /// brings in every required symbol from it (`Name`, `NameBase`,
+  /// `NameCodec`) so a single file's worth of references collapses
+  /// to one import statement.
+  List<String> _buildImportLines({
+    required String ownClassName,
+    required List<SerializableModelFieldDefinition> fields,
+    String? extraImport,
+  }) {
+    final referenced = <String>{};
+    for (final f in fields) {
+      _collectReferencedProjectTypes(f.type, referenced);
+    }
+    if (extraImport != null) referenced.add(extraImport);
+    referenced.remove(ownClassName); // never self-import
+
+    final sorted = referenced.toList()..sort();
+    return [
+      for (final ref in sorted)
+        "import { ${_importSymbols(ref).join(', ')} } from './${_filenameStemOf(ref)}.js';",
+    ];
+  }
+
+  /// Symbols we need to bring in from the file that defines [className].
+  /// Mirrors what `TsTypeMapper` emits at the use site:
+  ///   plain class       → just `Name`
+  ///   exception         → just `Name`
+  ///   sealed base       → `Name` (the union alias) + `NameBase` (dispatcher)
+  ///   enum              → `Name` + `NameCodec`
+  List<String> _importSymbols(String className) {
+    if (_enumClassNames.contains(className)) {
+      return [className, '${className}Codec'];
+    }
+    if (_sealedClassNames.contains(className)) {
+      return [className, '${className}Base'];
+    }
+    return [className];
+  }
+
   String _emitSealedBase(
     ModelClassDefinition model,
     List<ModelClassDefinition> subclasses,
@@ -117,12 +182,15 @@ class ModelEmitter {
     final w = TsWriter()
       ..writeRaw(_generatedHeader)
       ..writeln("import * as r from '../runtime/index.js';");
+    // Subclass imports are *value* imports — the switch dispatcher
+    // calls `Sub.fromJson(...)` so we need the runtime symbol.
     for (final sub in subclasses) {
-      w.writeln("import { ${sub.className} } from './${_filenameStemOf(sub.className)}.js';");
+      w.writeln(
+        "import { ${sub.className} } from './${_filenameStemOf(sub.className)}.js';",
+      );
     }
     w.blankLine();
 
-    // Discriminated-union type alias.
     final union = subclasses.isEmpty
         ? 'never'
         : subclasses.map((s) => s.className).join(' | ');
@@ -130,8 +198,6 @@ class ModelEmitter {
     w.writeln('export type ${model.className} = $union;');
     w.blankLine();
 
-    // Abstract base class — non-instantiable; carries the polymorphic
-    // `fromJson` dispatcher and a shared `toJson` contract.
     w.writeln(
       'export abstract class ${model.className}Base implements r.SerializableModel {',
     );
@@ -148,7 +214,6 @@ class ModelEmitter {
         w.writeln('switch (className) {');
         w.indent(() {
           for (final sub in subclasses) {
-            // Module prefix-aware: match both bare and `<module>.<Name>`.
             w.writeln(
               "case '${sub.className}': return ${sub.className}.fromJson(json);",
             );
@@ -170,19 +235,22 @@ class ModelEmitter {
     ModelClassDefinition model, {
     String? sealedAncestor,
   }) {
-    final w = TsWriter()
-      ..writeRaw(_generatedHeader)
-      ..writeln("import * as r from '../runtime/index.js';");
-    if (sealedAncestor != null) {
-      w.writeln(
-        "import { ${sealedAncestor}Base } from './${_filenameStemOf(sealedAncestor)}.js';",
-      );
-    }
-    w.blankLine();
-
     final fields = model.fields
         .where((f) => f.shouldIncludeField(false /* serverCode */))
         .toList();
+
+    final w = TsWriter()
+      ..writeRaw(_generatedHeader)
+      ..writeln("import * as r from '../runtime/index.js';");
+    final imports = _buildImportLines(
+      ownClassName: model.className,
+      fields: fields,
+      extraImport: sealedAncestor,
+    );
+    for (final line in imports) {
+      w.writeln(line);
+    }
+    w.blankLine();
 
     w.docComment(model.documentation?.join('\n'));
     if (sealedAncestor != null) {
@@ -195,7 +263,6 @@ class ModelEmitter {
       );
     }
     w.indent(() {
-      // Public fields
       for (final field in fields) {
         w.docComment(field.documentation?.join('\n'));
         final type = mapper.map(field.type);
@@ -203,7 +270,6 @@ class ModelEmitter {
       }
       w.blankLine();
 
-      // Constructor
       w.writeln('constructor(init: {');
       w.indent(() {
         for (final field in fields) {
@@ -221,7 +287,6 @@ class ModelEmitter {
       w.writeln('}');
       w.blankLine();
 
-      // fromJson
       w.writeln(
         'static fromJson(json: Record<string, unknown>): ${model.className} {',
       );
@@ -230,8 +295,7 @@ class ModelEmitter {
         w.indent(() {
           for (final field in fields) {
             final type = mapper.map(field.type);
-            final fromExpr =
-                type.fromJsonExpr("json['${field.name}']");
+            final fromExpr = type.fromJsonExpr("json['${field.name}']");
             w.writeln('${field.name}: $fromExpr,');
           }
         });
@@ -240,7 +304,6 @@ class ModelEmitter {
       w.writeln('}');
       w.blankLine();
 
-      // toJson
       w.writeln('toJson(): Record<string, unknown> {');
       w.indent(() {
         w.writeln('return {');
@@ -254,7 +317,9 @@ class ModelEmitter {
                 '{ ${field.name}: ${type.toJsonExpr('this.${field.name}')} }),',
               );
             } else {
-              w.writeln('${field.name}: ${type.toJsonExpr('this.${field.name}')},');
+              w.writeln(
+                '${field.name}: ${type.toJsonExpr('this.${field.name}')},',
+              );
             }
           }
         });
@@ -263,7 +328,6 @@ class ModelEmitter {
       w.writeln('}');
       w.blankLine();
 
-      // copyWith
       w.writeln('copyWith(partial: Partial<{');
       w.indent(() {
         for (final field in fields) {
@@ -277,10 +341,6 @@ class ModelEmitter {
         w.indent(() {
           for (final field in fields) {
             if (field.type.nullable) {
-              // Nullable fields honour `null` as a value: caller must
-              // be able to clear the field by passing `{ field: null }`.
-              // Distinguish "not in partial" from "in partial as null"
-              // via the `'field' in partial` check.
               w.writeln(
                 '${field.name}: '
                 "'${field.name}' in partial "
@@ -304,14 +364,21 @@ class ModelEmitter {
   }
 
   String _emitException(ExceptionClassDefinition model) {
-    final w = TsWriter()
-      ..writeRaw(_generatedHeader)
-      ..writeln("import * as r from '../runtime/index.js';")
-      ..blankLine();
-
     final fields = model.fields
         .where((f) => f.shouldIncludeField(false))
         .toList();
+
+    final w = TsWriter()
+      ..writeRaw(_generatedHeader)
+      ..writeln("import * as r from '../runtime/index.js';");
+    final imports = _buildImportLines(
+      ownClassName: model.className,
+      fields: fields,
+    );
+    for (final line in imports) {
+      w.writeln(line);
+    }
+    w.blankLine();
 
     w.docComment(model.documentation?.join('\n'));
     w.writeln(
@@ -334,8 +401,6 @@ class ModelEmitter {
       });
       w.writeln('}) {');
       w.indent(() {
-        // Best-effort: use `init.message` if there's a `message` field;
-        // otherwise the class name as the Error message.
         final hasMsg = fields.any((f) => f.name == 'message');
         if (hasMsg) {
           w.writeln('super(init.message as string);');
@@ -375,7 +440,9 @@ class ModelEmitter {
           w.writeln("__className__: '${model.className}',");
           for (final field in fields) {
             final type = mapper.map(field.type);
-            w.writeln('${field.name}: ${type.toJsonExpr('this.${field.name}')},');
+            w.writeln(
+              '${field.name}: ${type.toJsonExpr('this.${field.name}')},',
+            );
           }
         });
         w.writeln('};');
@@ -409,7 +476,6 @@ class ModelEmitter {
     final namespaceName = '${model.className}Codec';
     w.writeln('export const $namespaceName = {');
     w.indent(() {
-      // toJson
       if (byIndex) {
         w.writeln('toJson(value: ${model.className}): number {');
         w.indent(() {
@@ -430,7 +496,6 @@ class ModelEmitter {
         );
       }
       w.blankLine();
-      // fromJson
       w.writeln('fromJson(json: unknown): ${model.className} {');
       w.indent(() {
         if (byIndex) {
@@ -483,9 +548,6 @@ class ModelEmitter {
   }
 
   String _enumMemberName(String name) {
-    // TS enum members are valid identifiers; the value names from
-    // Serverpod YAML are already valid Dart identifiers, so simple
-    // capitalisation is safe.
     if (name.isEmpty) return name;
     return name[0].toUpperCase() + name.substring(1);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.1.2
+version: 0.1.3
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 

--- a/test/fixtures/sample_server/sample_client/lib/src/protocol/admin_profile.dart
+++ b/test/fixtures/sample_server/sample_client/lib/src/protocol/admin_profile.dart
@@ -12,6 +12,10 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'protocol.dart' as _i1;
 import 'package:serverpod_client/serverpod_client.dart' as _i2;
+import 'priority.dart' as _i3;
+import 'colour.dart' as _i4;
+import 'animal.dart' as _i5;
+import 'package:sample_client/src/protocol/protocol.dart' as _i6;
 
 /// Profile for an administrator.
 ///
@@ -30,6 +34,10 @@ abstract class AdminProfile extends _i1.UserProfile
     required super.karma,
     required super.deviceId,
     super.bio,
+    required super.priority,
+    super.favouriteColour,
+    super.pet,
+    required super.priorityHistory,
     required this.scope,
   });
 
@@ -44,6 +52,10 @@ abstract class AdminProfile extends _i1.UserProfile
     required BigInt karma,
     required _i2.UuidValue deviceId,
     String? bio,
+    required _i3.Priority priority,
+    _i4.Colour? favouriteColour,
+    _i5.Animal? pet,
+    required List<_i3.Priority> priorityHistory,
     required String scope,
   }) = _AdminProfileImpl;
 
@@ -65,6 +77,18 @@ abstract class AdminProfile extends _i1.UserProfile
         jsonSerialization['deviceId'],
       ),
       bio: jsonSerialization['bio'] as String?,
+      priority: _i3.Priority.fromJson((jsonSerialization['priority'] as int)),
+      favouriteColour: jsonSerialization['favouriteColour'] == null
+          ? null
+          : _i4.Colour.fromJson(
+              (jsonSerialization['favouriteColour'] as String),
+            ),
+      pet: jsonSerialization['pet'] == null
+          ? null
+          : _i6.Protocol().deserialize<_i5.Animal>(jsonSerialization['pet']),
+      priorityHistory: _i6.Protocol().deserialize<List<_i3.Priority>>(
+        jsonSerialization['priorityHistory'],
+      ),
       scope: jsonSerialization['scope'] as String,
     );
   }
@@ -87,6 +111,10 @@ abstract class AdminProfile extends _i1.UserProfile
     BigInt? karma,
     _i2.UuidValue? deviceId,
     Object? bio,
+    _i3.Priority? priority,
+    Object? favouriteColour,
+    Object? pet,
+    List<_i3.Priority>? priorityHistory,
     String? scope,
   });
   @override
@@ -103,6 +131,10 @@ abstract class AdminProfile extends _i1.UserProfile
       'karma': karma.toJson(),
       'deviceId': deviceId.toJson(),
       if (bio != null) 'bio': bio,
+      'priority': priority.toJson(),
+      if (favouriteColour != null) 'favouriteColour': favouriteColour?.toJson(),
+      if (pet != null) 'pet': pet?.toJson(),
+      'priorityHistory': priorityHistory.toJson(valueToJson: (v) => v.toJson()),
       'scope': scope,
     };
   }
@@ -127,6 +159,10 @@ class _AdminProfileImpl extends AdminProfile {
     required BigInt karma,
     required _i2.UuidValue deviceId,
     String? bio,
+    required _i3.Priority priority,
+    _i4.Colour? favouriteColour,
+    _i5.Animal? pet,
+    required List<_i3.Priority> priorityHistory,
     required String scope,
   }) : super._(
          id: id,
@@ -139,6 +175,10 @@ class _AdminProfileImpl extends AdminProfile {
          karma: karma,
          deviceId: deviceId,
          bio: bio,
+         priority: priority,
+         favouriteColour: favouriteColour,
+         pet: pet,
+         priorityHistory: priorityHistory,
          scope: scope,
        );
 
@@ -157,6 +197,10 @@ class _AdminProfileImpl extends AdminProfile {
     BigInt? karma,
     _i2.UuidValue? deviceId,
     Object? bio = _Undefined,
+    _i3.Priority? priority,
+    Object? favouriteColour = _Undefined,
+    Object? pet = _Undefined,
+    List<_i3.Priority>? priorityHistory,
     String? scope,
   }) {
     return AdminProfile(
@@ -170,6 +214,13 @@ class _AdminProfileImpl extends AdminProfile {
       karma: karma ?? this.karma,
       deviceId: deviceId ?? this.deviceId,
       bio: bio is String? ? bio : this.bio,
+      priority: priority ?? this.priority,
+      favouriteColour: favouriteColour is _i4.Colour?
+          ? favouriteColour
+          : this.favouriteColour,
+      pet: pet is _i5.Animal? ? pet : this.pet?.copyWith(),
+      priorityHistory:
+          priorityHistory ?? this.priorityHistory.map((e0) => e0).toList(),
       scope: scope ?? this.scope,
     );
   }

--- a/test/fixtures/sample_server/sample_client/lib/src/protocol/protocol.dart
+++ b/test/fixtures/sample_server/sample_client/lib/src/protocol/protocol.dart
@@ -101,6 +101,10 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i7.UserProfile?>()) {
       return (data != null ? _i7.UserProfile.fromJson(data) : null) as T;
     }
+    if (t == List<_i6.Priority>) {
+      return (data as List).map((e) => deserialize<_i6.Priority>(e)).toList()
+          as T;
+    }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as T;
     }

--- a/test/fixtures/sample_server/sample_client/lib/src/protocol/user_profile.dart
+++ b/test/fixtures/sample_server/sample_client/lib/src/protocol/user_profile.dart
@@ -11,6 +11,10 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'priority.dart' as _i2;
+import 'colour.dart' as _i3;
+import 'package:sample_client/src/protocol/protocol.dart' as _i4;
+import 'animal.dart' as _i5;
 
 /// A user profile.
 ///
@@ -29,6 +33,10 @@ class UserProfile implements _i1.SerializableModel {
     required this.karma,
     required this.deviceId,
     this.bio,
+    required this.priority,
+    this.favouriteColour,
+    this.pet,
+    required this.priorityHistory,
   });
 
   factory UserProfile.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -49,6 +57,18 @@ class UserProfile implements _i1.SerializableModel {
         jsonSerialization['deviceId'],
       ),
       bio: jsonSerialization['bio'] as String?,
+      priority: _i2.Priority.fromJson((jsonSerialization['priority'] as int)),
+      favouriteColour: jsonSerialization['favouriteColour'] == null
+          ? null
+          : _i3.Colour.fromJson(
+              (jsonSerialization['favouriteColour'] as String),
+            ),
+      pet: jsonSerialization['pet'] == null
+          ? null
+          : _i4.Protocol().deserialize<_i5.Animal>(jsonSerialization['pet']),
+      priorityHistory: _i4.Protocol().deserialize<List<_i2.Priority>>(
+        jsonSerialization['priorityHistory'],
+      ),
     );
   }
 
@@ -82,6 +102,22 @@ class UserProfile implements _i1.SerializableModel {
   /// Optional bio markdown blob.
   String? bio;
 
+  /// Account priority — exercises a cross-model enum field reference
+  /// (forces the model emitter to emit `import { Priority, PriorityCodec }`).
+  _i2.Priority priority;
+
+  /// Favourite colour — exercises a cross-model enum field reference
+  /// with `byName` serialization.
+  _i3.Colour? favouriteColour;
+
+  /// Pet — exercises a cross-model field referencing a sealed hierarchy
+  /// (forces `import { Animal, AnimalBase }`).
+  _i5.Animal? pet;
+
+  /// Tags — exercises a generic-wrapped enum reference (`List<Priority>`
+  /// should still pull a Priority import).
+  List<_i2.Priority> priorityHistory;
+
   /// Returns a shallow copy of this [UserProfile]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
@@ -96,6 +132,10 @@ class UserProfile implements _i1.SerializableModel {
     BigInt? karma,
     _i1.UuidValue? deviceId,
     Object? bio = _Undefined,
+    _i2.Priority? priority,
+    Object? favouriteColour = _Undefined,
+    Object? pet = _Undefined,
+    List<_i2.Priority>? priorityHistory,
   }) {
     return UserProfile(
       id: id ?? this.id,
@@ -108,6 +148,13 @@ class UserProfile implements _i1.SerializableModel {
       karma: karma ?? this.karma,
       deviceId: deviceId ?? this.deviceId,
       bio: bio is String? ? bio : this.bio,
+      priority: priority ?? this.priority,
+      favouriteColour: favouriteColour is _i3.Colour?
+          ? favouriteColour
+          : this.favouriteColour,
+      pet: pet is _i5.Animal? ? pet : this.pet?.copyWith(),
+      priorityHistory:
+          priorityHistory ?? this.priorityHistory.map((e0) => e0).toList(),
     );
   }
 
@@ -125,6 +172,10 @@ class UserProfile implements _i1.SerializableModel {
       'karma': karma.toJson(),
       'deviceId': deviceId.toJson(),
       if (bio != null) 'bio': bio,
+      'priority': priority.toJson(),
+      if (favouriteColour != null) 'favouriteColour': favouriteColour?.toJson(),
+      if (pet != null) 'pet': pet?.toJson(),
+      'priorityHistory': priorityHistory.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/test/fixtures/sample_server/sample_server/lib/src/endpoints/models_endpoint.dart
+++ b/test/fixtures/sample_server/sample_server/lib/src/endpoints/models_endpoint.dart
@@ -35,6 +35,10 @@ class ModelsEndpoint extends Endpoint {
       karma: profile.karma,
       deviceId: profile.deviceId,
       bio: profile.bio,
+      priority: profile.priority,
+      favouriteColour: profile.favouriteColour,
+      pet: profile.pet,
+      priorityHistory: profile.priorityHistory,
       scope: scope,
     );
   }

--- a/test/fixtures/sample_server/sample_server/lib/src/generated/admin_profile.dart
+++ b/test/fixtures/sample_server/sample_server/lib/src/generated/admin_profile.dart
@@ -12,6 +12,10 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
+import 'priority.dart' as _i3;
+import 'colour.dart' as _i4;
+import 'animal.dart' as _i5;
+import 'package:sample_server/src/generated/protocol.dart' as _i6;
 
 /// Profile for an administrator.
 ///
@@ -30,6 +34,10 @@ abstract class AdminProfile extends _i1.UserProfile
     required super.karma,
     required super.deviceId,
     super.bio,
+    required super.priority,
+    super.favouriteColour,
+    super.pet,
+    required super.priorityHistory,
     required this.scope,
   });
 
@@ -44,6 +52,10 @@ abstract class AdminProfile extends _i1.UserProfile
     required BigInt karma,
     required _i2.UuidValue deviceId,
     String? bio,
+    required _i3.Priority priority,
+    _i4.Colour? favouriteColour,
+    _i5.Animal? pet,
+    required List<_i3.Priority> priorityHistory,
     required String scope,
   }) = _AdminProfileImpl;
 
@@ -65,6 +77,18 @@ abstract class AdminProfile extends _i1.UserProfile
         jsonSerialization['deviceId'],
       ),
       bio: jsonSerialization['bio'] as String?,
+      priority: _i3.Priority.fromJson((jsonSerialization['priority'] as int)),
+      favouriteColour: jsonSerialization['favouriteColour'] == null
+          ? null
+          : _i4.Colour.fromJson(
+              (jsonSerialization['favouriteColour'] as String),
+            ),
+      pet: jsonSerialization['pet'] == null
+          ? null
+          : _i6.Protocol().deserialize<_i5.Animal>(jsonSerialization['pet']),
+      priorityHistory: _i6.Protocol().deserialize<List<_i3.Priority>>(
+        jsonSerialization['priorityHistory'],
+      ),
       scope: jsonSerialization['scope'] as String,
     );
   }
@@ -87,6 +111,10 @@ abstract class AdminProfile extends _i1.UserProfile
     BigInt? karma,
     _i2.UuidValue? deviceId,
     Object? bio,
+    _i3.Priority? priority,
+    Object? favouriteColour,
+    Object? pet,
+    List<_i3.Priority>? priorityHistory,
     String? scope,
   });
   @override
@@ -103,6 +131,10 @@ abstract class AdminProfile extends _i1.UserProfile
       'karma': karma.toJson(),
       'deviceId': deviceId.toJson(),
       if (bio != null) 'bio': bio,
+      'priority': priority.toJson(),
+      if (favouriteColour != null) 'favouriteColour': favouriteColour?.toJson(),
+      if (pet != null) 'pet': pet?.toJson(),
+      'priorityHistory': priorityHistory.toJson(valueToJson: (v) => v.toJson()),
       'scope': scope,
     };
   }
@@ -121,6 +153,10 @@ abstract class AdminProfile extends _i1.UserProfile
       'karma': karma.toJson(),
       'deviceId': deviceId.toJson(),
       if (bio != null) 'bio': bio,
+      'priority': priority.toJson(),
+      if (favouriteColour != null) 'favouriteColour': favouriteColour?.toJson(),
+      if (pet != null) 'pet': pet?.toJsonForProtocol(),
+      'priorityHistory': priorityHistory.toJson(valueToJson: (v) => v.toJson()),
       'scope': scope,
     };
   }
@@ -145,6 +181,10 @@ class _AdminProfileImpl extends AdminProfile {
     required BigInt karma,
     required _i2.UuidValue deviceId,
     String? bio,
+    required _i3.Priority priority,
+    _i4.Colour? favouriteColour,
+    _i5.Animal? pet,
+    required List<_i3.Priority> priorityHistory,
     required String scope,
   }) : super._(
          id: id,
@@ -157,6 +197,10 @@ class _AdminProfileImpl extends AdminProfile {
          karma: karma,
          deviceId: deviceId,
          bio: bio,
+         priority: priority,
+         favouriteColour: favouriteColour,
+         pet: pet,
+         priorityHistory: priorityHistory,
          scope: scope,
        );
 
@@ -175,6 +219,10 @@ class _AdminProfileImpl extends AdminProfile {
     BigInt? karma,
     _i2.UuidValue? deviceId,
     Object? bio = _Undefined,
+    _i3.Priority? priority,
+    Object? favouriteColour = _Undefined,
+    Object? pet = _Undefined,
+    List<_i3.Priority>? priorityHistory,
     String? scope,
   }) {
     return AdminProfile(
@@ -188,6 +236,13 @@ class _AdminProfileImpl extends AdminProfile {
       karma: karma ?? this.karma,
       deviceId: deviceId ?? this.deviceId,
       bio: bio is String? ? bio : this.bio,
+      priority: priority ?? this.priority,
+      favouriteColour: favouriteColour is _i4.Colour?
+          ? favouriteColour
+          : this.favouriteColour,
+      pet: pet is _i5.Animal? ? pet : this.pet?.copyWith(),
+      priorityHistory:
+          priorityHistory ?? this.priorityHistory.map((e0) => e0).toList(),
       scope: scope ?? this.scope,
     );
   }

--- a/test/fixtures/sample_server/sample_server/lib/src/generated/protocol.dart
+++ b/test/fixtures/sample_server/sample_server/lib/src/generated/protocol.dart
@@ -105,6 +105,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i8.UserProfile?>()) {
       return (data != null ? _i8.UserProfile.fromJson(data) : null) as T;
     }
+    if (t == List<_i7.Priority>) {
+      return (data as List).map((e) => deserialize<_i7.Priority>(e)).toList()
+          as T;
+    }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as T;
     }

--- a/test/fixtures/sample_server/sample_server/lib/src/generated/user_profile.dart
+++ b/test/fixtures/sample_server/sample_server/lib/src/generated/user_profile.dart
@@ -11,6 +11,10 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'priority.dart' as _i2;
+import 'colour.dart' as _i3;
+import 'package:sample_server/src/generated/protocol.dart' as _i4;
+import 'animal.dart' as _i5;
 
 /// A user profile.
 ///
@@ -29,6 +33,10 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
     required this.karma,
     required this.deviceId,
     this.bio,
+    required this.priority,
+    this.favouriteColour,
+    this.pet,
+    required this.priorityHistory,
   });
 
   factory UserProfile.fromJson(Map<String, dynamic> jsonSerialization) {
@@ -49,6 +57,18 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
         jsonSerialization['deviceId'],
       ),
       bio: jsonSerialization['bio'] as String?,
+      priority: _i2.Priority.fromJson((jsonSerialization['priority'] as int)),
+      favouriteColour: jsonSerialization['favouriteColour'] == null
+          ? null
+          : _i3.Colour.fromJson(
+              (jsonSerialization['favouriteColour'] as String),
+            ),
+      pet: jsonSerialization['pet'] == null
+          ? null
+          : _i4.Protocol().deserialize<_i5.Animal>(jsonSerialization['pet']),
+      priorityHistory: _i4.Protocol().deserialize<List<_i2.Priority>>(
+        jsonSerialization['priorityHistory'],
+      ),
     );
   }
 
@@ -82,6 +102,22 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
   /// Optional bio markdown blob.
   String? bio;
 
+  /// Account priority — exercises a cross-model enum field reference
+  /// (forces the model emitter to emit `import { Priority, PriorityCodec }`).
+  _i2.Priority priority;
+
+  /// Favourite colour — exercises a cross-model enum field reference
+  /// with `byName` serialization.
+  _i3.Colour? favouriteColour;
+
+  /// Pet — exercises a cross-model field referencing a sealed hierarchy
+  /// (forces `import { Animal, AnimalBase }`).
+  _i5.Animal? pet;
+
+  /// Tags — exercises a generic-wrapped enum reference (`List<Priority>`
+  /// should still pull a Priority import).
+  List<_i2.Priority> priorityHistory;
+
   /// Returns a shallow copy of this [UserProfile]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
@@ -96,6 +132,10 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
     BigInt? karma,
     _i1.UuidValue? deviceId,
     Object? bio = _Undefined,
+    _i2.Priority? priority,
+    Object? favouriteColour = _Undefined,
+    Object? pet = _Undefined,
+    List<_i2.Priority>? priorityHistory,
   }) {
     return UserProfile(
       id: id ?? this.id,
@@ -108,6 +148,13 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
       karma: karma ?? this.karma,
       deviceId: deviceId ?? this.deviceId,
       bio: bio is String? ? bio : this.bio,
+      priority: priority ?? this.priority,
+      favouriteColour: favouriteColour is _i3.Colour?
+          ? favouriteColour
+          : this.favouriteColour,
+      pet: pet is _i5.Animal? ? pet : this.pet?.copyWith(),
+      priorityHistory:
+          priorityHistory ?? this.priorityHistory.map((e0) => e0).toList(),
     );
   }
 
@@ -125,6 +172,10 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
       'karma': karma.toJson(),
       'deviceId': deviceId.toJson(),
       if (bio != null) 'bio': bio,
+      'priority': priority.toJson(),
+      if (favouriteColour != null) 'favouriteColour': favouriteColour?.toJson(),
+      if (pet != null) 'pet': pet?.toJson(),
+      'priorityHistory': priorityHistory.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -142,6 +193,10 @@ class UserProfile implements _i1.SerializableModel, _i1.ProtocolSerialization {
       'karma': karma.toJson(),
       'deviceId': deviceId.toJson(),
       if (bio != null) 'bio': bio,
+      'priority': priority.toJson(),
+      if (favouriteColour != null) 'favouriteColour': favouriteColour?.toJson(),
+      if (pet != null) 'pet': pet?.toJsonForProtocol(),
+      'priorityHistory': priorityHistory.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/test/fixtures/sample_server/sample_server/lib/src/models/user_profile.spy.yaml
+++ b/test/fixtures/sample_server/sample_server/lib/src/models/user_profile.spy.yaml
@@ -34,3 +34,19 @@ fields:
 
   ### Optional bio markdown blob.
   bio: String?
+
+  ### Account priority — exercises a cross-model enum field reference
+  ### (forces the model emitter to emit `import { Priority, PriorityCodec }`).
+  priority: Priority
+
+  ### Favourite colour — exercises a cross-model enum field reference
+  ### with `byName` serialization.
+  favouriteColour: Colour?
+
+  ### Pet — exercises a cross-model field referencing a sealed hierarchy
+  ### (forces `import { Animal, AnimalBase }`).
+  pet: Animal?
+
+  ### Tags — exercises a generic-wrapped enum reference (`List<Priority>`
+  ### should still pull a Priority import).
+  priorityHistory: List<Priority>


### PR DESCRIPTION
Bugfix: model emitter wasn't emitting imports for fields whose type referenced other project models. `tsc --noEmit` reported TS2304 for non-trivial Serverpod projects. Each model file now walks its field types (descending into generics) and emits the right import per referenced type — `Name` for plain/exception, `Name + NameBase` for sealed, `Name + NameCodec` for enum. Fixture extended to regression-test it. Bumps to v0.1.3.