### PR TITLE
fix: void return type + unknown fallback for module-defined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.1.4
+
+- Bugfix: type mapper now handles `void`, `dynamic`, and `Object`
+  explicitly. Previously these fell through to the project-model branch
+  and emitted invalid `p.void.fromJson(...)` / `p.dynamic` etc.,
+  breaking `tsc --noEmit` on any endpoint with a `Future<void>` return.
+- Bugfix: types defined in Serverpod modules the project depends on
+  (e.g. `AuthSuccess` from `serverpod_auth_idp`) are no longer
+  emitted as `p.AuthSuccess`. Until module-aware imports land in v0.2,
+  they fall back to `unknown /* TODO(v0.2): module type AuthSuccess */`
+  so the package compiles and the gap is surfaced via the IDE hover.
+  Endpoint-side callers can cast at the call site.
+- The mapper now takes a `projectClassNames` set so it can distinguish
+  "in our protocol/ barrel" from "defined in a module dependency". The
+  generate command computes this from the IR's models list and passes
+  it through to both model and endpoint emitters.
+
 ## 0.1.3
 
 - Bugfix: model emitter now emits cross-file imports for fields whose

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -121,12 +121,14 @@ class GenerateCommand extends Command<int> {
         .whereType<EnumDefinition>()
         .map((e) => e.className)
         .toSet();
+    final projectClassNames = {for (final m in ir.models) m.className};
     ModelEmitter(
       outputDir: paths.outputDir,
       tracker: tracker,
       mapper: TsTypeMapper(
         sealedClassNames: sealedClassNames,
         enumClassNames: enumClassNames,
+        projectClassNames: projectClassNames,
       ),
     ).emitAll(ir.models);
     EndpointEmitter(
@@ -136,6 +138,7 @@ class GenerateCommand extends Command<int> {
         modelPrefix: 'p.',
         sealedClassNames: sealedClassNames,
         enumClassNames: enumClassNames,
+        projectClassNames: projectClassNames,
       ),
     ).emitAll(ir.endpoints);
     ClientEmitter(

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -36,8 +36,10 @@ class TsTypeMapper {
     this.modelPrefix = '',
     Set<String>? sealedClassNames,
     Set<String>? enumClassNames,
+    Set<String>? projectClassNames,
   })  : sealedClassNames = sealedClassNames ?? const {},
-        enumClassNames = enumClassNames ?? const {};
+        enumClassNames = enumClassNames ?? const {},
+        projectClassNames = projectClassNames ?? const {};
 
   final String modelPrefix;
 
@@ -52,6 +54,13 @@ class TsTypeMapper {
   /// `<Name>Codec.toJson(value)` and `<Name>Codec.fromJson(json)`
   /// instead of `<value>.toJson()` / `<Name>.fromJson(json)`.
   final Set<String> enumClassNames;
+
+  /// Every class name emitted as part of THIS project (sealed, enum,
+  /// regular class, exception). Anything not in here is a foreign
+  /// type — typically defined in a Serverpod module the project
+  /// depends on. v0.1.x stubs foreign types as `unknown`; v0.2 will
+  /// emit a real cross-package import.
+  final Set<String> projectClassNames;
 
   TsTypeRef map(TypeDefinition type) {
     final base = _mapInner(type);
@@ -122,6 +131,19 @@ class TsTypeMapper {
           toJsonExpr: (v) => v,
           fromJsonExpr: (v) => v,
         );
+      case 'void':
+        // Endpoint emitter inspects `tsReturnInner == 'void'` and emits
+        // `() => undefined as void` for the decoder, so the to/from
+        // expressions here are unreachable in practice. Keep them
+        // identity-passes for safety.
+        return TsTypeRef(
+          tsType: 'void',
+          toJsonExpr: (v) => v,
+          fromJsonExpr: (v) => 'undefined as void',
+        );
+      case 'dynamic':
+      case 'Object':
+        return _passthrough('unknown');
       default:
         return _mapModelOrEnum(type);
     }
@@ -181,6 +203,22 @@ class TsTypeMapper {
 
   TsTypeRef _mapModelOrEnum(TypeDefinition type) {
     final qualifiedType = '$modelPrefix${type.className}';
+
+    // Foreign type — typically defined in a Serverpod module the
+    // project depends on (e.g. AuthSuccess from serverpod_auth_idp).
+    // v0.1.x falls back to `unknown` so the package compiles; v0.2
+    // will emit real `import type { ... } from '<module-ts-pkg>';`
+    // statements based on `TypeDefinition.url`.
+    if (projectClassNames.isNotEmpty &&
+        !projectClassNames.contains(type.className)) {
+      return TsTypeRef(
+        // The `unknown` cast keeps tsc happy and surfaces the gap to
+        // users via the IDE's hover.
+        tsType: 'unknown /* TODO(v0.2): module type ${type.className} */',
+        toJsonExpr: (v) => '$v as unknown',
+        fromJsonExpr: (v) => '$v as unknown',
+      );
+    }
 
     if (enumClassNames.contains(type.className)) {
       // Enums use a sibling `<Name>Codec` object for both directions.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 


### PR DESCRIPTION
Closes the immediate `endpoint_verification_token.ts` build failure. `void` is now in the primitives switch (no more `p.void.fromJson`); types not in the project IR (typically defined in Serverpod module deps like `AuthSuccess` from `serverpod_auth_idp`) fall back to `unknown` with a TODO(v0.2) comment instead of `p.AuthSuccess`. Bumps to v0.1.4. Real module-aware imports come in v0.2.