### PR TITLE
v0.2.0: module-aware generation (cross-package imports + protocol dispatch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: npm install (TypeScript runtime)
-        run: npm install
+      - name: npm ci (TypeScript runtime)
+        run: npm ci
         working-directory: lib/runtime/typescript
 
       - name: dart analyze
@@ -56,6 +56,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install
+      - run: npm ci
       - run: npm run typecheck
       - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 0.2.0
+
+- Module-aware generation. The CLI now walks `.dart_tool/package_config.json`
+  for the project's Serverpod module dependencies and recursively generates a
+  TS client for each as a sibling of the app client (default
+  `<server>/../<module>_typescript_client/`). The app client's `package.json`
+  declares the module clients via `file:..` deps so a single `npm install`
+  resolves the whole graph in place — no npm publishing required.
+- Cross-package emission. Model and endpoint files now emit
+  `import { Name<, NameBase>?<, NameCodec>? } from '<module-pkg>';` lines for
+  every module-defined type they reference, instead of falling back to the
+  v0.1.4 `unknown /* TODO */` placeholder. Sealed bases bring in `Name + NameBase`,
+  enums bring in `Name + NameCodec`, plain classes bring in `Name`.
+- Protocol switch dispatches module classes. The generated `Protocol`'s
+  `deserializeByClassName` switch now contains a case per referenced module
+  class — dispatching through the bare imported symbol — so the wire form
+  `auth.AuthSuccess` round-trips into a real typed value rather than `unknown`.
+- New CLI flag `--no-gen-modules` skips the recursive module generation
+  (default: enabled). Useful when module clients are managed separately.
+- New optional `typescript_client_modules:` block in `config/generator.yaml`
+  overrides the per-module output directory or npm package name:
+  ```yaml
+  typescript_client_modules:
+    serverpod_auth_idp_server:
+      output: ../my_custom_path
+      npm_name: '@my-org/auth-idp-ts'
+  ```
+- Internal: extracted `lib/src/analyzer/ir_walker.dart` (shared IR walks),
+  `lib/src/emit/module_import_lines.dart` (cross-package import grouping),
+  and `lib/src/cli/generation_pipeline.dart` (single per-project flow used
+  by both the app and every module dep).
+
 ## 0.1.4
 
 - Bugfix: type mapper now handles `void`, `dynamic`, and `Object`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,5 +70,5 @@ Both rely on the runtime's `node_modules` having been installed (see the local-s
 2. Update `CHANGELOG.md`.
 3. Verify the full suite is green: `dart analyze && dart test && (cd lib/runtime/typescript && npm test)`.
 4. Run the external smoke-test: generate against a non-fixture Serverpod project (e.g. a fresh `serverpod create -t mini -n smoke` outside this repo) and verify the output is `tsc --noEmit` clean.
-5. Commit + tag: `git tag v<version> && git push --tags`.
+5. Commit + tag + push (commit AND tag): `git commit -am "Release v<version>" && git tag v<version> && git push --follow-tags`.
 6. (Optional, deferred to v0.2) `dart pub publish` once stabilised.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate a fully-typed TypeScript client for a Serverpod project — drop-in par
 
 ## Status
 
-**v0.1 — usable.** The generator produces a tsc-clean, type-safe TypeScript client for any Serverpod project against the surface listed below. See the support matrix for known limitations.
+**v0.2 — module-aware.** The generator produces a tsc-clean, type-safe TypeScript client for any Serverpod project, including projects that depend on modules (`serverpod_auth_idp_server`, `serverpod_cloud_storage_s3`, etc.). Module clients are generated in-place as siblings of the app client and wired through `file:..` deps — no npm publishing required.
 
 ## Quick start
 
@@ -20,14 +20,16 @@ dart run serverpod_typescript_bridge generate
 Pass `--no-build` if you want source files only (e.g. you're on
 pnpm/yarn/bun, or your CI runs the build step itself).
 
-This writes a sibling package to your existing Dart client:
+This writes a sibling package to your existing Dart client. If your server depends on Serverpod modules, each is generated as an additional sibling and the app client picks them up via `file:..` deps:
 
 ```
 my_app/
-├── my_app_server/                   # your Serverpod server package
-├── my_app_client/                   # serverpod-generated Dart client
-└── my_app_typescript_client/        # serverpod_typescript_bridge output
-    ├── package.json
+├── my_app_server/                                # your Serverpod server package
+├── my_app_client/                                # serverpod-generated Dart client
+├── serverpod_auth_idp_typescript_client/         # auto-generated (per module dep)
+├── serverpod_cloud_storage_s3_typescript_client/ # auto-generated (per module dep)
+└── my_app_typescript_client/                     # serverpod_typescript_bridge output
+    ├── package.json                              # `file:..` deps wired automatically
     ├── tsconfig.json
     └── src/
         ├── client.ts                # top-level Client
@@ -36,6 +38,8 @@ my_app/
         ├── protocol/                # one TS class per model
         └── endpoints/               # one TS class per endpoint
 ```
+
+Pass `--no-gen-modules` to skip recursive module generation (e.g. when module clients are managed separately).
 
 Then in your TS/React app:
 
@@ -46,7 +50,7 @@ const client = new Client('https://api.my-app.com');
 const greeting = await client.greeting.sayHello('world');
 ```
 
-## Supported in v0.1
+## Supported in v0.2
 
 | Feature | Status | Notes |
 |---|---|---|
@@ -62,19 +66,20 @@ const greeting = await client.greeting.sayHello('world');
 | Enums | ✅ | both `byIndex` and `byName` |
 | Exceptions | ✅ | `SerializableException` subclasses extend `Error` and round-trip via `Protocol` |
 | Modules (`type: module`) | ✅ | emits `<Nickname>Caller extends ModuleEndpointCaller` + `modulePrefix` const |
-| Module-prefix `__className__` | ✅ | Protocol switch normalises `<prefix>.<Class>` → bare `<Class>` |
+| Module dependencies (consumer side) | ✅ | recursively generates a TS client per module, wires `file:..` deps in `package.json`, emits cross-package `import { Name } from '<module-pkg>';` lines |
+| Cross-module protocol dispatch | ✅ | Protocol switch routes `<prefix>.<Class>` envelopes through the matching module's `<Name>(.fromJson\|Codec.fromJson\|Base.fromJson)` |
 | HTTP unary calls | ✅ | fetch-based; status mapping; auth header; one-shot 401 refresh |
 | Output streams | ✅ | `Stream<T>` returns → `AsyncIterable<T>`; WebSocket transport |
 | Bidirectional streams | ✅ | `Stream<T>` parameter → `streams: { name: AsyncIterable<T> }`; values forwarded as `MethodStreamMessage` frames |
 | Typed exceptions | ✅ | `{className, data}` envelope decoded via `Protocol.deserializeByClassName` |
 
-## Out of scope for v0.1
+## Out of scope (post-v0.2)
 
 | Feature | Tracker |
 |---|---|
-| Records (Dart 3 records as endpoint params/return) | post-v0.1 |
-| Watch mode (`-w`) | post-v0.1 |
-| Module client npm publishing (currently vendored) | v0.2 |
+| Records (Dart 3 records as endpoint params/return) | post-v0.2 |
+| Watch mode (`-w`) | post-v0.2 |
+| Typed module-Caller surface (currently `Modules.<nickname>: unknown` stub; cross-package types resolve directly through their imports) | post-v0.2 |
 | `dart run serverpod_typescript_bridge inspect` polish | works, but undocumented; primarily a debug surface |
 
 ## CLI reference
@@ -96,15 +101,30 @@ Options:
                     Defaults to <server>/../<name>_typescript_client/.
                     Override via `typescript_client_package_path` in
                     `config/generator.yaml`.
-      --[no-]build  After emitting source, run `npm install` + `npm run build`
-                    in the output directory so it is import-ready (default: on).
+      --[no-]build         After emitting source, run `npm install` + `npm run build`
+                           in the output directory so it is import-ready (default: on).
+      --[no-]gen-modules   Recursively generate TS clients for every Serverpod
+                           module the project depends on, as siblings of the app
+                           client (default: on). The app client picks them up via
+                           `file:..` deps wired automatically into `package.json`.
+```
+
+### Customising module client paths
+
+By default each module client is generated at `<server>/../<module-stripped-of-_server>_typescript_client/` and named `<module-stripped>_typescript_client` in npm. Override per module via `config/generator.yaml`:
+
+```yaml
+typescript_client_modules:
+  serverpod_auth_idp_server:
+    output: ../my_custom_path
+    npm_name: '@my-org/auth-idp-ts'
 ```
 
 ## How it works
 
 The generator is a Dart-side tool that reuses **`serverpod_cli`'s public analyzer** to load the IR for your Serverpod project, then walks that IR and emits TypeScript. Because the IR is the same one Serverpod uses internally, there's no parser drift — every feature Serverpod knows about flows through automatically.
 
-The generated client depends on a small TypeScript runtime that ships *vendored* inside each generated package (under `src/runtime/`). v0.2 will publish the runtime to npm and switch generated packages to declare it as a dependency; existing v0.1 clients re-generate cleanly into v0.2.
+The generated client depends on a small TypeScript runtime that ships *vendored* inside each generated package (under `src/runtime/`). Module dependencies are detected by scanning `.dart_tool/package_config.json` for packages whose `config/generator.yaml` declares `type: module`. Each module's IR is loaded the same way the app's is, used to build a cross-package class index, and emitted as its own sibling TypeScript client; the app client then declares each module client as a `file:..` dependency so a single `npm install` resolves the whole graph in place.
 
 For the full architecture, see [docs/architecture.md](docs/architecture.md).
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -20,3 +20,7 @@ paths:
   - test/ts_writer_test.dart
   - test/module_emission_test.dart
   - test/bidi_streaming_emission_test.dart
+  - test/module_discoverer_test.dart
+  - test/module_client_layout_test.dart
+  - test/module_import_lines_test.dart
+  - test/client_emitter_modules_test.dart

--- a/lib/runtime/typescript/src/ws_messages.ts
+++ b/lib/runtime/typescript/src/ws_messages.ts
@@ -63,8 +63,15 @@ export interface MethodStreamMessageData {
    * the server sent to the client.
    */
   parameter?: string;
-  /** `{ className, data }` envelope per `wrapWithClassName` in Dart. */
-  object: { className: string; data: Record<string, unknown> };
+  /**
+   * `{ className, data }` envelope per `wrapWithClassName` in Dart.
+   *
+   * `data` is `unknown` rather than `Record<…>` because stream values
+   * can serialize to a primitive, an array, or an object depending on
+   * the type mapper output. The receiver-side decoder is responsible
+   * for validating the actual JSON shape.
+   */
+  object: { className: string; data: unknown };
 }
 
 export interface MethodStreamSerializableExceptionData {

--- a/lib/runtime/typescript/src/ws_transport.ts
+++ b/lib/runtime/typescript/src/ws_transport.ts
@@ -16,10 +16,15 @@ import {
  * server-side method. The encoder turns each value into the
  * `{ className, data }` envelope the server expects on
  * `MethodStreamMessage.object`.
+ *
+ * `data` is intentionally `unknown`: stream values can serialize to a
+ * primitive, an array, or a record (see `r.encodeList`/etc.), so the
+ * generated encoder isn't always producing a JSON object. The wire
+ * payload preserves whatever shape the type mapper emits.
  */
 export interface InputStreamSpec<T = unknown> {
   iterable: AsyncIterable<T>;
-  encode: (value: T) => { className: string; data: Record<string, unknown> };
+  encode: (value: T) => { className: string; data: unknown };
 }
 
 /**
@@ -43,7 +48,15 @@ export class ClientMethodStreamManager {
   async open(): Promise<void> {
     if (this.socket && this.socket.readyState === WebSocket.OPEN) return;
     if (this.socketReady) return this.socketReady;
-    this.socketReady = this._connect();
+    // Cache the connect promise so concurrent open() calls share it.
+    // Crucially, clear the cache on rejection so callers can retry —
+    // otherwise a single transient failure would poison every future
+    // call by always returning the same rejected promise.
+    this.socketReady = this._connect().catch((e) => {
+      this.socketReady = undefined;
+      this.socket = undefined;
+      throw e;
+    });
     return this.socketReady;
   }
 
@@ -58,6 +71,20 @@ export class ClientMethodStreamManager {
         () => reject(new ServerpodClientException('WebSocket error', 0)),
         { once: true },
       );
+      // A 'close' arriving before 'open' (auth failure, immediate
+      // server reject) would otherwise leave this await hanging
+      // forever. Treat it as a failed handshake.
+      ws.addEventListener(
+        'close',
+        () =>
+          reject(
+            new ServerpodClientException(
+              'WebSocket closed before open',
+              0,
+            ),
+          ),
+        { once: true },
+      );
     });
     ws.addEventListener('message', (e) => this._onMessage(String(e.data)));
     ws.addEventListener('close', () => this._onClose());
@@ -68,8 +95,12 @@ export class ClientMethodStreamManager {
       ? this.host.slice(0, -1)
       : this.host;
     let url = base.replace(/^http/, 'ws') + '/v1/websocket';
-    const auth = await this.authProvider?.getAuthHeaderValue();
-    if (auth) url += `?auth=${encodeURIComponent(auth)}`;
+    // The auth provider returns a wrapped header value (e.g.
+    // `Bearer <key>`). Serverpod's WS contract expects the raw key in
+    // the `?auth=` query param, so strip the scheme prefix if present.
+    const headerValue = await this.authProvider?.getAuthHeaderValue();
+    const rawKey = _extractRawAuthKey(headerValue);
+    if (rawKey) url += `?auth=${encodeURIComponent(rawKey)}`;
     return url;
   }
 
@@ -100,18 +131,53 @@ export class ClientMethodStreamManager {
         this.handlers.get(data.connectionId)?.onClose();
         return;
       }
-      // ping/pong handled at the WebSocket layer; bad_request surfaces
-      // via the connection-level error path.
+      case 'ping':
+        // Serverpod uses app-level ping/pong (browsers can't reply to
+        // WS control frames). Echo back so the server doesn't drop us.
+        this.socket?.send(buildEnvelope('pong', {}));
+        return;
+      case 'pong':
+        // No keepalive timer yet; just consume.
+        return;
+      case 'bad_request': {
+        // The server can't parse what we sent. Tear every active
+        // handler down with a connection-level error rather than
+        // silently leaking pending iterators.
+        const err = new ServerpodClientException(
+          'Server reported bad_request on the WebSocket; closing',
+          400,
+        );
+        this._failAllHandlers(err);
+        this.socket?.close();
+        return;
+      }
       default:
         return;
     }
   }
 
   private _onClose(): void {
-    for (const h of this.handlers.values()) h.onClose();
+    // Reject any pending open handshakes so callers awaiting
+    // `openResponse` don't hang forever after a mid-handshake drop.
+    const err = new ServerpodClientException(
+      'WebSocket closed before stream completed',
+      0,
+    );
+    for (const h of this.handlers.values()) {
+      h.failOpenIfPending(err);
+      h.onClose();
+    }
     this.handlers.clear();
     this.socket = undefined;
     this.socketReady = undefined;
+  }
+
+  private _failAllHandlers(err: unknown): void {
+    for (const h of this.handlers.values()) {
+      h.failOpenIfPending(err);
+      h.onError(err);
+    }
+    this.handlers.clear();
   }
 
   /**
@@ -146,8 +212,15 @@ export class ClientMethodStreamManager {
 
     const handler = new _StreamHandler(opts.decode, this.serializer);
     this.handlers.set(connectionId, handler);
-    this.socket!.send(buildEnvelope('open_method_stream_command', command));
-    await handler.openResponse;
+    try {
+      this.socket!.send(buildEnvelope('open_method_stream_command', command));
+      await handler.openResponse;
+    } catch (e) {
+      // Failed open → eject the handler so it doesn't keep routing
+      // messages to a stream the caller never receives.
+      this.handlers.delete(connectionId);
+      throw e;
+    }
 
     // Spawn a feeder per input stream. Each runs in the background
     // for the lifetime of the call.
@@ -247,6 +320,11 @@ export class ClientMethodStreamManager {
   }
 }
 
+type _Waiter = {
+  resolve: (v: IteratorResult<unknown>) => void;
+  reject: (e: unknown) => void;
+};
+
 class _StreamHandler {
   constructor(
     private readonly decode: (raw: unknown) => unknown,
@@ -254,9 +332,10 @@ class _StreamHandler {
   ) {}
 
   private readonly _values: unknown[] = [];
-  private readonly _waiters: Array<(v: IteratorResult<unknown>) => void> = [];
+  private readonly _waiters: _Waiter[] = [];
   private _error: unknown | undefined;
   private _closed = false;
+  private _openSettled = false;
   private _openResolve: (() => void) | undefined;
   private _openReject: ((e: unknown) => void) | undefined;
 
@@ -266,33 +345,52 @@ class _StreamHandler {
   });
 
   onOpenResponse(data: OpenMethodStreamResponseData): void {
+    this._openSettled = true;
     if (data.responseType === 'success') {
       this._openResolve?.();
-    } else {
-      this._openReject?.(
-        new ServerpodClientException(
-          `Failed to open stream: ${data.responseType}`,
-          0,
-        ),
-      );
+      return;
     }
+    this._openReject?.(_openErrorFor(data.responseType));
+  }
+
+  /// Called by the manager when the connection drops before the
+  /// open-response arrives. Without this, callers can hang forever
+  /// awaiting `openResponse`.
+  failOpenIfPending(err: unknown): void {
+    if (this._openSettled) return;
+    this._openSettled = true;
+    this._openReject?.(err);
   }
 
   onValue(data: MethodStreamMessageData): void {
     if (this._closed) return;
-    const value = this.decode(data.object.data);
+    // Pass the full envelope so the decoder sees both `className` and
+    // `data` — the generated `Protocol.deserializeByClassName` walks
+    // the envelope; passing only `data` discards polymorphic dispatch.
+    const value = this.decode(data.object);
     this._dispatch(value);
   }
 
   onException(data: MethodStreamSerializableExceptionData): void {
     const err = this.serializer.deserializeByClassName(data.object);
-    this._error = err instanceof Error
-      ? err
-      : new ServerpodClientException(
-          `Stream exception: ${data.object.className}`,
-          0,
-        );
-    this._dispatchEnd();
+    this.onError(
+      err instanceof Error
+        ? err
+        : new ServerpodClientException(
+            `Stream exception: ${data.object.className}`,
+            0,
+          ),
+    );
+  }
+
+  /// Terminates the stream with an error. Any already-awaiting
+  /// consumers receive the error through their `next()` rejection;
+  /// later consumers re-throw the cached `_error` synchronously.
+  onError(err: unknown): void {
+    if (this._closed) return;
+    this._error = err;
+    this._closed = true;
+    this._dispatchError(err);
   }
 
   onClose(): void {
@@ -304,7 +402,7 @@ class _StreamHandler {
   private _dispatch(value: unknown): void {
     const waiter = this._waiters.shift();
     if (waiter) {
-      waiter({ value, done: false });
+      waiter.resolve({ value, done: false });
     } else {
       this._values.push(value);
     }
@@ -312,7 +410,13 @@ class _StreamHandler {
 
   private _dispatchEnd(): void {
     while (this._waiters.length > 0) {
-      this._waiters.shift()!({ value: undefined, done: true });
+      this._waiters.shift()!.resolve({ value: undefined, done: true });
+    }
+  }
+
+  private _dispatchError(err: unknown): void {
+    while (this._waiters.length > 0) {
+      this._waiters.shift()!.reject(err);
     }
   }
 
@@ -322,9 +426,10 @@ class _StreamHandler {
       [Symbol.asyncIterator](): AsyncIterator<T> {
         return {
           next(): Promise<IteratorResult<T>> {
-            return new Promise<IteratorResult<unknown>>((resolve) => {
+            return new Promise<IteratorResult<unknown>>((resolve, reject) => {
               if (self._error) {
-                throw self._error;
+                reject(self._error);
+                return;
               }
               if (self._values.length > 0) {
                 resolve({ value: self._values.shift(), done: false });
@@ -334,7 +439,7 @@ class _StreamHandler {
                 resolve({ value: undefined, done: true });
                 return;
               }
-              self._waiters.push(resolve);
+              self._waiters.push({ resolve, reject });
             }) as Promise<IteratorResult<T>>;
           },
           async return(value): Promise<IteratorResult<T>> {
@@ -346,4 +451,51 @@ class _StreamHandler {
       },
     };
   }
+}
+
+/// Maps a non-success `responseType` from the server's open-stream
+/// response onto the closest HTTP-style status so callers can
+/// `instanceof`-check against the existing exception hierarchy.
+function _openErrorFor(responseType: string): ServerpodClientException {
+  switch (responseType) {
+    case 'endpointNotFound':
+      return new ServerpodClientException(
+        'Endpoint not found',
+        404,
+      );
+    case 'authenticationFailed':
+      return new ServerpodClientException(
+        'Authentication failed',
+        401,
+      );
+    case 'authorizationDeclined':
+      return new ServerpodClientException(
+        'Authorization declined',
+        403,
+      );
+    case 'invalidArguments':
+      return new ServerpodClientException(
+        'Invalid arguments',
+        400,
+      );
+    default:
+      return new ServerpodClientException(
+        `Failed to open stream: ${responseType}`,
+        0,
+      );
+  }
+}
+
+/// Strips a header-style prefix (`Bearer foo`, `Basic abc=`) from
+/// [headerValue] and returns just the raw key the WS query expects.
+function _extractRawAuthKey(
+  headerValue: string | null | undefined,
+): string | undefined {
+  if (!headerValue) return undefined;
+  const trimmed = headerValue.trim();
+  if (!trimmed) return undefined;
+  const sep = trimmed.indexOf(' ');
+  if (sep === -1) return trimmed;
+  const rest = trimmed.slice(sep + 1).trim();
+  return rest || undefined;
 }

--- a/lib/src/analyzer/ir_walker.dart
+++ b/lib/src/analyzer/ir_walker.dart
@@ -1,0 +1,61 @@
+// ignore_for_file: implementation_imports
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart'
+    show EndpointDefinition;
+
+/// Pure walks over the Serverpod IR — extracted so emitters and the
+/// generation pipeline don't each re-implement the same parameter /
+/// generic descent. Every helper is read-only and side-effect-free.
+class IrWalker {
+  IrWalker._();
+
+  /// Yields every [TypeDefinition] referenced by [ep] across return
+  /// types and parameters (required-positional, optional-positional,
+  /// and named). Callers wanting deeper recursion through generics
+  /// should compose this with [walkType].
+  static Iterable<TypeDefinition> endpointTypeRefs(
+    EndpointDefinition ep,
+  ) sync* {
+    for (final m in ep.methods) {
+      yield m.returnType;
+      for (final pm in m.parameters) {
+        yield pm.type;
+      }
+      for (final pm in m.parametersPositional) {
+        yield pm.type;
+      }
+      for (final pm in m.parametersNamed) {
+        yield pm.type;
+      }
+    }
+  }
+
+  /// Returns every className referenced anywhere in [ir] — model
+  /// fields, exception fields, and endpoint params/returns — descending
+  /// into generics. Used to scope cross-package emission to only the
+  /// types the project actually pulls from.
+  static Set<String> allReferencedClassNames(ProtocolDefinition ir) {
+    final out = <String>{};
+    for (final model in ir.models) {
+      if (model is ClassDefinition) {
+        for (final f in model.fields) {
+          walkType(f.type, out);
+        }
+      }
+    }
+    for (final ep in ir.endpoints) {
+      for (final t in endpointTypeRefs(ep)) {
+        walkType(t, out);
+      }
+    }
+    return out;
+  }
+
+  /// Adds [t]'s className plus every nested generic className to [out].
+  static void walkType(TypeDefinition t, Set<String> out) {
+    out.add(t.className);
+    for (final g in t.generics) {
+      walkType(g, out);
+    }
+  }
+}

--- a/lib/src/analyzer/protocol_loader.dart
+++ b/lib/src/analyzer/protocol_loader.dart
@@ -55,10 +55,15 @@ class ProtocolLoader {
         serverRootDir: serverDirectory.path,
         interactive: false,
       );
-    } catch (e) {
-      throw ProtocolLoaderException._(
-        ProtocolLoaderPhase.config,
-        'Failed to load GeneratorConfig from ${serverDirectory.path}: $e',
+    } catch (e, st) {
+      // Preserve the original stack trace so config-load failures
+      // remain debuggable; we only translate the exception type.
+      Error.throwWithStackTrace(
+        ProtocolLoaderException._(
+          ProtocolLoaderPhase.config,
+          'Failed to load GeneratorConfig from ${serverDirectory.path}: $e',
+        ),
+        st,
       );
     }
   }

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -151,9 +151,24 @@ class GenerateCommand extends Command<int> {
 
     stdout.writeln('Wrote TypeScript client to ${appPaths.outputDir.path}');
 
-    // 4. Run npm install + npm run build against the APP client only.
-    //    Module clients are resolved transitively via file: deps.
+    // 4. Build module clients first, then the app. The app's tsc
+    //    consumes module `dist/` outputs through the `file:..` deps;
+    //    if those `dist/` directories don't exist yet the app's
+    //    typecheck fails (`Cannot find module 'auth_typescript_client'
+    //    or its corresponding type declarations`). npm doesn't run
+    //    `prepare` for `file:` deps, so we have to drive the builds
+    //    ourselves and in dependency order.
     if (ar['build'] as bool) {
+      for (final mod in discovered) {
+        final layout = layoutResolver.resolve(mod.dartPkgName);
+        final modWarn =
+            await PostBuildRunner(outputDir: layout.outputDir).run();
+        if (modWarn != null) {
+          stderr.writeln(
+            'Module client ${mod.dartPkgName} build skipped: $modWarn',
+          );
+        }
+      }
       final warning =
           await PostBuildRunner(outputDir: appPaths.outputDir).run();
       if (warning != null) {

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -2,26 +2,23 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 
 import '../analyzer/protocol_loader.dart';
+import '../discovery/module_class_index.dart';
+import '../discovery/module_client_layout.dart';
+import '../discovery/module_discoverer.dart';
 import '../discovery/server_directory_finder.dart';
-import '../emit/client_emitter.dart';
-import '../emit/endpoint_emitter.dart';
-import '../emit/generated_file_tracker.dart';
-import '../emit/model_emitter.dart';
 import '../emit/output_paths.dart';
-import '../emit/scaffold_emitter.dart';
-import '../emit/ts_type_mapper.dart';
+import 'generation_pipeline.dart';
 import 'post_build_runner.dart';
 
 /// `generate` — produce the TypeScript client package for a Serverpod
-/// project. Default: emits source AND runs `npm install` + `npm run
-/// build` so the resulting package is import-ready. Pass `--no-build`
-/// to skip the install + build steps (e.g. for non-npm toolchains
-/// or CI pipelines that build separately).
+/// project. Defaults: discovers every Serverpod module the project
+/// depends on, generates a TS client for each as a sibling of the app
+/// client, then generates the app client with `file:..` deps wired up
+/// and `npm install` + `npm run build` run at the end.
 class GenerateCommand extends Command<int> {
   GenerateCommand() {
     argParser
@@ -45,6 +42,14 @@ class GenerateCommand extends Command<int> {
         help: 'After emitting source, run `npm install` + `npm run '
             'build` in the output directory so it is import-ready. '
             'Pass `--no-build` to skip; you can build manually later.',
+      )
+      ..addFlag(
+        'gen-modules',
+        defaultsTo: true,
+        help: 'Recursively generate TS clients for every Serverpod '
+            'module the project depends on (placed as siblings of the '
+            'app client). Pass `--no-gen-modules` to skip — only useful '
+            'if you manage module clients separately.',
       );
   }
 
@@ -81,79 +86,76 @@ class GenerateCommand extends Command<int> {
       return 70;
     }
 
-    final paths = OutputPaths.resolve(
+    final appPaths = OutputPaths.resolve(
       config,
       explicitOutput: ar['output'] as String?,
     );
 
-    final ProtocolDefinition ir;
+    // Pre-flight the IR for the app — fail fast on analyzer errors
+    // before discovering modules (recursive failures are harder to
+    // attribute back to the caller).
     try {
-      ir = await ProtocolLoader.load(serverDir);
+      await ProtocolLoader.load(serverDir);
     } on ProtocolLoaderException catch (e) {
       stderr.writeln(e.message);
       return 70;
     }
 
-    final tracker = GeneratedFileTracker([
-      Directory(p.join(paths.outputDir.path, 'src', 'runtime')),
-      Directory(p.join(paths.outputDir.path, 'src', 'protocol')),
-      Directory(p.join(paths.outputDir.path, 'src', 'endpoints')),
-    ]);
-
-    final scaffold = ScaffoldEmitter(
-      outputPaths: paths,
-      tracker: tracker,
-      additionalBarrelExports: const [
-        './protocol/index.js',
-        './endpoints/index.js',
-        './protocol.js',
-        './client.js',
-      ],
-    );
-    await scaffold.emit();
-
-    final sealedClassNames = ir.models
-        .whereType<ModelClassDefinition>()
-        .where((m) => m.isSealed)
-        .map((m) => m.className)
-        .toSet();
-    final enumClassNames = ir.models
-        .whereType<EnumDefinition>()
-        .map((e) => e.className)
-        .toSet();
-    final projectClassNames = {for (final m in ir.models) m.className};
-    ModelEmitter(
-      outputDir: paths.outputDir,
-      tracker: tracker,
-      mapper: TsTypeMapper(
-        sealedClassNames: sealedClassNames,
-        enumClassNames: enumClassNames,
-        projectClassNames: projectClassNames,
-      ),
-    ).emitAll(ir.models);
-    EndpointEmitter(
-      outputDir: paths.outputDir,
-      tracker: tracker,
-      mapper: TsTypeMapper(
-        modelPrefix: 'p.',
-        sealedClassNames: sealedClassNames,
-        enumClassNames: enumClassNames,
-        projectClassNames: projectClassNames,
-      ),
-    ).emitAll(ir.endpoints);
-    ClientEmitter(
-      outputDir: paths.outputDir,
-      tracker: tracker,
+    final layoutResolver = ModuleLayoutResolver(
+      appClientOutputDir: appPaths.outputDir,
       config: config,
-    ).emit(endpoints: ir.endpoints, models: ir.models);
+    );
 
-    tracker.sweepOrphans();
+    // 1. Discover modules + build the cross-package class index.
+    final discovered = (ar['gen-modules'] as bool)
+        ? _discoverModules(serverDir)
+        : <DiscoveredModule>[];
+    final moduleIndex = await ModuleClassIndex.build(
+      discovered: discovered,
+      layoutResolver: layoutResolver,
+    );
 
-    stdout.writeln('Wrote TypeScript client to ${paths.outputDir.path}');
+    // 2. Generate each discovered module FIRST so the app client can
+    //    declare `file:..` deps that resolve cleanly.
+    for (final mod in discovered) {
+      final layout = layoutResolver.resolve(mod.dartPkgName);
+      stdout.writeln(
+        'Generating module client: ${mod.dartPkgName} → '
+        '${layout.outputDir.path}',
+      );
+      try {
+        await GenerationPipeline.run(
+          serverDir: mod.serverPkgDir,
+          outputDir: layout.outputDir,
+          moduleIndex: moduleIndex,
+        );
+      } catch (e) {
+        stderr.writeln(
+          'Failed to generate module ${mod.dartPkgName}: $e',
+        );
+        return 70;
+      }
+    }
 
+    // 3. Generate the app client with module-aware imports + deps.
+    try {
+      await GenerationPipeline.run(
+        serverDir: serverDir,
+        outputDir: appPaths.outputDir,
+        moduleIndex: moduleIndex,
+      );
+    } catch (e) {
+      stderr.writeln('Failed to generate app client: $e');
+      return 70;
+    }
+
+    stdout.writeln('Wrote TypeScript client to ${appPaths.outputDir.path}');
+
+    // 4. Run npm install + npm run build against the APP client only.
+    //    Module clients are resolved transitively via file: deps.
     if (ar['build'] as bool) {
       final warning =
-          await PostBuildRunner(outputDir: paths.outputDir).run();
+          await PostBuildRunner(outputDir: appPaths.outputDir).run();
       if (warning != null) {
         stderr.writeln(warning);
       } else {
@@ -167,6 +169,18 @@ class GenerateCommand extends Command<int> {
       );
     }
     return 0;
+  }
+
+  List<DiscoveredModule> _discoverModules(Directory serverDir) {
+    try {
+      return ModuleDiscoverer.discover(serverDir);
+    } on StateError catch (e) {
+      stderr.writeln(
+        'Skipping module discovery: ${e.message}\n'
+        'Pass `--no-gen-modules` to suppress this attempt.',
+      );
+      return const [];
+    }
   }
 
   static bool _experimentalFeaturesInitialised = false;

--- a/lib/src/cli/generation_pipeline.dart
+++ b/lib/src/cli/generation_pipeline.dart
@@ -1,0 +1,147 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+
+import '../analyzer/ir_walker.dart';
+import '../analyzer/protocol_loader.dart';
+import '../discovery/module_class_index.dart';
+import '../emit/client_emitter.dart';
+import '../emit/endpoint_emitter.dart';
+import '../emit/generated_file_tracker.dart';
+import '../emit/model_emitter.dart';
+import '../emit/output_paths.dart';
+import '../emit/scaffold_emitter.dart';
+import '../emit/ts_type_mapper.dart';
+
+/// One end-to-end generation against a single Serverpod server
+/// package — used by [GenerateCommand] for both the user's app and
+/// every module dependency. Doesn't run the post-build (npm install +
+/// build); the command runs that once at the end against the app.
+class GenerationPipeline {
+  /// Generates a TypeScript client for the project at [serverDir],
+  /// writing to [outputDir]. [moduleIndex] supplies cross-package
+  /// import information for types defined in OTHER modules the
+  /// project (transitively) depends on.
+  static Future<void> run({
+    required Directory serverDir,
+    required Directory outputDir,
+    required ModuleClassIndex moduleIndex,
+  }) async {
+    final config = await _loadConfig(serverDir);
+    final ir = await ProtocolLoader.load(serverDir);
+
+    final paths = OutputPaths(
+      outputDir: outputDir,
+      packageName: '${config.name}_typescript_client',
+    );
+
+    final tracker = GeneratedFileTracker([
+      Directory(p.join(outputDir.path, 'src', 'runtime')),
+      Directory(p.join(outputDir.path, 'src', 'protocol')),
+      Directory(p.join(outputDir.path, 'src', 'endpoints')),
+    ]);
+
+    final referencedClassNames = IrWalker.allReferencedClassNames(ir);
+    final moduleDeps = moduleIndex.referencedPackages(
+      referencedClassNames: referencedClassNames,
+      appClientDir: outputDir,
+    );
+
+    // Restrict the protocol-switch helper to only the referenced names
+    // that genuinely live in a module — anything else stays project-local
+    // (or is foreign and falls through to `undefined`).
+    final referencedModuleClassNames = <String>{
+      for (final name in referencedClassNames)
+        if (moduleIndex.layoutFor(name) != null) name,
+    };
+
+    final scaffold = ScaffoldEmitter(
+      outputPaths: paths,
+      tracker: tracker,
+      additionalBarrelExports: const [
+        './protocol/index.js',
+        './endpoints/index.js',
+        './protocol.js',
+        './client.js',
+      ],
+      moduleDependencies: moduleDeps,
+    );
+    await scaffold.emit();
+
+    final mapperConfig = _MapperConfig.fromIr(ir, moduleIndex);
+
+    ModelEmitter(
+      outputDir: outputDir,
+      tracker: tracker,
+      mapper: mapperConfig.build(modelPrefix: ''),
+    ).emitAll(ir.models);
+    EndpointEmitter(
+      outputDir: outputDir,
+      tracker: tracker,
+      mapper: mapperConfig.build(modelPrefix: 'p.'),
+    ).emitAll(ir.endpoints);
+    ClientEmitter(
+      outputDir: outputDir,
+      tracker: tracker,
+      config: config,
+      moduleIndex: moduleIndex,
+      referencedModuleClassNames: referencedModuleClassNames,
+    ).emit(endpoints: ir.endpoints, models: ir.models);
+
+    tracker.sweepOrphans();
+  }
+
+  static Future<GeneratorConfig> _loadConfig(Directory serverDir) async {
+    return GeneratorConfig.load(
+      serverRootDir: serverDir.path,
+      interactive: false,
+    );
+  }
+}
+
+/// Bundles every shape the [TsTypeMapper] needs about a project's
+/// own IR so the model and endpoint mappers can be constructed from a
+/// single derivation pass instead of duplicating the same five
+/// arguments at each call site.
+class _MapperConfig {
+  _MapperConfig._({
+    required this.sealedClassNames,
+    required this.enumClassNames,
+    required this.projectClassNames,
+    required this.moduleIndex,
+  });
+
+  factory _MapperConfig.fromIr(
+    ProtocolDefinition ir,
+    ModuleClassIndex moduleIndex,
+  ) {
+    return _MapperConfig._(
+      sealedClassNames: ir.models
+          .whereType<ModelClassDefinition>()
+          .where((m) => m.isSealed)
+          .map((m) => m.className)
+          .toSet(),
+      enumClassNames:
+          ir.models.whereType<EnumDefinition>().map((e) => e.className).toSet(),
+      projectClassNames: {for (final m in ir.models) m.className},
+      moduleIndex: moduleIndex,
+    );
+  }
+
+  final Set<String> sealedClassNames;
+  final Set<String> enumClassNames;
+  final Set<String> projectClassNames;
+  final ModuleClassIndex moduleIndex;
+
+  TsTypeMapper build({required String modelPrefix}) {
+    return TsTypeMapper(
+      modelPrefix: modelPrefix,
+      sealedClassNames: sealedClassNames,
+      enumClassNames: enumClassNames,
+      projectClassNames: projectClassNames,
+      moduleIndex: moduleIndex,
+    );
+  }
+}

--- a/lib/src/cli/generation_pipeline.dart
+++ b/lib/src/cli/generation_pipeline.dart
@@ -43,17 +43,23 @@ class GenerationPipeline {
       Directory(p.join(outputDir.path, 'src', 'endpoints')),
     ]);
 
+    final mapperConfig = _MapperConfig.fromIr(ir, moduleIndex);
+
+    // Local types always shadow the module index — see
+    // `TsTypeMapper._mapModelOrEnum`. Filter them out before we ask
+    // the index for `file:..` deps or protocol-switch entries; they
+    // belong to THIS package, not to a sibling module.
+    final localNames = mapperConfig.projectClassNames;
     final referencedClassNames = IrWalker.allReferencedClassNames(ir);
+    final referencedExternalNames = referencedClassNames.difference(localNames);
+
     final moduleDeps = moduleIndex.referencedPackages(
-      referencedClassNames: referencedClassNames,
-      appClientDir: outputDir,
+      referencedClassNames: referencedExternalNames,
+      consumerDir: outputDir,
     );
 
-    // Restrict the protocol-switch helper to only the referenced names
-    // that genuinely live in a module — anything else stays project-local
-    // (or is foreign and falls through to `undefined`).
     final referencedModuleClassNames = <String>{
-      for (final name in referencedClassNames)
+      for (final name in referencedExternalNames)
         if (moduleIndex.layoutFor(name) != null) name,
     };
 
@@ -69,8 +75,6 @@ class GenerationPipeline {
       moduleDependencies: moduleDeps,
     );
     await scaffold.emit();
-
-    final mapperConfig = _MapperConfig.fromIr(ir, moduleIndex);
 
     ModelEmitter(
       outputDir: outputDir,

--- a/lib/src/cli/post_build_runner.dart
+++ b/lib/src/cli/post_build_runner.dart
@@ -61,26 +61,45 @@ class PostBuildRunner {
   }
 
   /// Returns the platform-specific `npm` executable, or null if missing.
+  ///
+  /// On systems where `which`/`where` themselves aren't available (or
+  /// process spawning is blocked) the lookup must NOT crash `generate`
+  /// — post-build is intentionally non-fatal. We swallow [ProcessException]
+  /// and treat it the same as "npm not found".
   String? _resolveNpm() {
     final candidates = Platform.isWindows
         ? const ['npm.cmd', 'npm']
         : const ['npm'];
     for (final c in candidates) {
-      final result = Process.runSync(
-        Platform.isWindows ? 'where' : 'which',
-        [c],
-      );
-      if (result.exitCode == 0 &&
-          (result.stdout as String).trim().isNotEmpty) {
-        return c;
+      try {
+        final result = Process.runSync(
+          Platform.isWindows ? 'where' : 'which',
+          [c],
+        );
+        if (result.exitCode == 0 &&
+            (result.stdout as String).trim().isNotEmpty) {
+          return c;
+        }
+      } on ProcessException {
+        return null;
       }
     }
     return null;
   }
 
+  /// Quotes [outputDir]'s path so a copy-pasted recovery command works
+  /// even when the path contains spaces, quotes, or shell metacharacters.
+  String _quotedOutputDirPath() {
+    final path = outputDir.path;
+    if (Platform.isWindows) {
+      return '"${path.replaceAll('"', r'\"')}"';
+    }
+    return "'${path.replaceAll("'", r"'\''")}'";
+  }
+
   String _hint(String reason) {
     return '$reason\n'
-        '  cd ${outputDir.path}\n'
+        '  cd ${_quotedOutputDirPath()}\n'
         '  npm install\n'
         '  npm run build';
   }

--- a/lib/src/discovery/module_class_index.dart
+++ b/lib/src/discovery/module_class_index.dart
@@ -1,0 +1,103 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:serverpod_cli/analyzer.dart';
+
+import '../analyzer/protocol_loader.dart';
+import 'module_client_layout.dart';
+import 'module_discoverer.dart';
+
+/// Records which classes (models, exceptions, enums) are emitted by
+/// each Serverpod module the project depends on. Built once per
+/// generation run by analyzing each module's IR.
+///
+/// The type mapper consults this when emitting model fields + endpoint
+/// signatures: if a referenced className lives in a module, the emitter
+/// imports it from that module's TS client package instead of treating
+/// it as a local protocol-barrel reference (or the v0.1.x `unknown`
+/// fallback).
+class ModuleClassIndex {
+  ModuleClassIndex._(
+    Map<String, ModuleClientLayout> classToLayout,
+    Set<String> sealedClassNames,
+    Set<String> enumClassNames,
+  )   : _classToLayout = Map.unmodifiable(classToLayout),
+        _sealedClassNames = Set.unmodifiable(sealedClassNames),
+        _enumClassNames = Set.unmodifiable(enumClassNames);
+
+  final Map<String, ModuleClientLayout> _classToLayout;
+  final Set<String> _sealedClassNames;
+  final Set<String> _enumClassNames;
+
+  static final ModuleClassIndex empty =
+      ModuleClassIndex._(const {}, const {}, const {});
+
+  /// Constructs an index directly from already-resolved maps. Intended
+  /// for unit tests that need a controlled index without spinning up a
+  /// real Serverpod fixture; production code should always go through
+  /// [build] which derives the contents from each module's IR.
+  @visibleForTesting
+  static ModuleClassIndex forTesting({
+    required Map<String, ModuleClientLayout> classToLayout,
+    Set<String> sealedClassNames = const {},
+    Set<String> enumClassNames = const {},
+  }) {
+    return ModuleClassIndex._(classToLayout, sealedClassNames, enumClassNames);
+  }
+
+  /// Walks every [discovered] module, loads its IR, and builds a
+  /// `className → layout` index. Sealed/enum class names are tracked
+  /// separately so the emitter knows which import-symbol set to bring
+  /// in (`Name + NameBase` for sealed, `Name + NameCodec` for enum).
+  static Future<ModuleClassIndex> build({
+    required List<DiscoveredModule> discovered,
+    required ModuleLayoutResolver layoutResolver,
+  }) async {
+    final classToLayout = <String, ModuleClientLayout>{};
+    final sealedClassNames = <String>{};
+    final enumClassNames = <String>{};
+
+    for (final mod in discovered) {
+      final layout = layoutResolver.resolve(mod.dartPkgName);
+      final ir = await ProtocolLoader.load(mod.serverPkgDir);
+      for (final m in ir.models) {
+        classToLayout[m.className] = layout;
+        if (m is ModelClassDefinition && m.isSealed) {
+          sealedClassNames.add(m.className);
+        } else if (m is EnumDefinition) {
+          enumClassNames.add(m.className);
+        }
+      }
+    }
+
+    return ModuleClassIndex._(classToLayout, sealedClassNames,
+        enumClassNames);
+  }
+
+  bool get isEmpty => _classToLayout.isEmpty;
+
+  /// Returns the layout for [className] if it's defined in any module,
+  /// or null if it's local / unknown.
+  ModuleClientLayout? layoutFor(String className) =>
+      _classToLayout[className];
+
+  bool isSealed(String className) => _sealedClassNames.contains(className);
+  bool isEnum(String className) => _enumClassNames.contains(className);
+
+  /// All className → npmPackageName entries, deduplicated by package.
+  /// Used by the scaffold emitter to write the right `file:..` deps
+  /// into the consuming package's `package.json`.
+  Map<String, String> referencedPackages({
+    required Iterable<String> referencedClassNames,
+    required Directory appClientDir,
+  }) {
+    final out = <String, String>{};
+    for (final name in referencedClassNames) {
+      final layout = _classToLayout[name];
+      if (layout == null) continue;
+      out[layout.npmPackageName] = 'file:${layout.relativeFromAppClient}';
+    }
+    return out;
+  }
+}

--- a/lib/src/discovery/module_class_index.dart
+++ b/lib/src/discovery/module_class_index.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 
 import '../analyzer/protocol_loader.dart';
@@ -85,19 +86,37 @@ class ModuleClassIndex {
   bool isSealed(String className) => _sealedClassNames.contains(className);
   bool isEnum(String className) => _enumClassNames.contains(className);
 
-  /// All className → npmPackageName entries, deduplicated by package.
-  /// Used by the scaffold emitter to write the right `file:..` deps
-  /// into the consuming package's `package.json`.
+  /// All `npmPackageName → "file:<relative-path>"` entries the
+  /// consuming package needs to declare in its `package.json`,
+  /// deduplicated by package.
+  ///
+  /// The relative path is computed fresh from [consumerDir] →
+  /// the module's `outputDir` and forced to posix slashes — npm
+  /// expects forward slashes in `file:` deps even on Windows. This
+  /// also lets module clients depend on each other (consumer is the
+  /// generating module's own output dir, not the app's).
   Map<String, String> referencedPackages({
     required Iterable<String> referencedClassNames,
-    required Directory appClientDir,
+    required Directory consumerDir,
   }) {
     final out = <String, String>{};
     for (final name in referencedClassNames) {
       final layout = _classToLayout[name];
       if (layout == null) continue;
-      out[layout.npmPackageName] = 'file:${layout.relativeFromAppClient}';
+      out[layout.npmPackageName] = 'file:${_posixRelative(
+        from: consumerDir.path,
+        to: layout.outputDir.path,
+      )}';
     }
     return out;
+  }
+
+  /// Relative path from [from] → [to] using forward slashes,
+  /// regardless of host platform. We canonicalise both ends before
+  /// asking the path package so symlinks and `..` segments don't
+  /// produce surprising results.
+  static String _posixRelative({required String from, required String to}) {
+    final platformRel = p.relative(p.canonicalize(to), from: p.canonicalize(from));
+    return p.split(platformRel).join('/');
   }
 }

--- a/lib/src/discovery/module_client_layout.dart
+++ b/lib/src/discovery/module_client_layout.dart
@@ -7,12 +7,17 @@ import 'package:yaml/yaml.dart';
 
 /// Where one module's generated TS client lives, and what the rest of
 /// the codebase calls it.
+///
+/// The relative path used in `file:..` package.json deps is computed
+/// fresh by [ModuleClassIndex.referencedPackages] from the consuming
+/// directory — that way module clients can depend on each other (or
+/// on themselves through alternate paths) without a hard-coded
+/// app-relative path going stale.
 class ModuleClientLayout {
   ModuleClientLayout({
     required this.dartPkgName,
     required this.outputDir,
     required this.npmPackageName,
-    required this.relativeFromAppClient,
   });
 
   /// The Dart module's pkg name (e.g. `serverpod_auth_idp_server`).
@@ -24,11 +29,6 @@ class ModuleClientLayout {
   /// The `name` field that goes in the module client's `package.json`.
   /// Must match the file: dep entry the app client declares.
   final String npmPackageName;
-
-  /// The relative path the app client's `package.json` uses (e.g.
-  /// `../serverpod_auth_idp_typescript_client`). Used for `file:..`
-  /// dependency resolution.
-  final String relativeFromAppClient;
 
   @override
   String toString() => 'ModuleClientLayout($dartPkgName → '
@@ -75,16 +75,10 @@ class ModuleLayoutResolver {
 
     final npmName = override?.npmName ?? defaultDirName;
 
-    final relativeFromAppClient = p.relative(
-      outputDir.path,
-      from: appClientOutputDir.path,
-    );
-
     return ModuleClientLayout(
       dartPkgName: dartPkgName,
       outputDir: outputDir,
       npmPackageName: npmName,
-      relativeFromAppClient: relativeFromAppClient,
     );
   }
 

--- a/lib/src/discovery/module_client_layout.dart
+++ b/lib/src/discovery/module_client_layout.dart
@@ -1,0 +1,151 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:yaml/yaml.dart';
+
+/// Where one module's generated TS client lives, and what the rest of
+/// the codebase calls it.
+class ModuleClientLayout {
+  ModuleClientLayout({
+    required this.dartPkgName,
+    required this.outputDir,
+    required this.npmPackageName,
+    required this.relativeFromAppClient,
+  });
+
+  /// The Dart module's pkg name (e.g. `serverpod_auth_idp_server`).
+  final String dartPkgName;
+
+  /// Where the module's TS client should be written.
+  final Directory outputDir;
+
+  /// The `name` field that goes in the module client's `package.json`.
+  /// Must match the file: dep entry the app client declares.
+  final String npmPackageName;
+
+  /// The relative path the app client's `package.json` uses (e.g.
+  /// `../serverpod_auth_idp_typescript_client`). Used for `file:..`
+  /// dependency resolution.
+  final String relativeFromAppClient;
+
+  @override
+  String toString() => 'ModuleClientLayout($dartPkgName → '
+      '${outputDir.path}, npm=$npmPackageName)';
+}
+
+/// Computes [ModuleClientLayout]s for every module a project depends
+/// on. Default convention puts each module client as a sibling of the
+/// app client, named `<module>_typescript_client` (matching the
+/// Dart-side `<module>_client` convention).
+///
+/// Overrideable via `typescript_client_modules:` in
+/// `config/generator.yaml`:
+///
+/// ```yaml
+/// typescript_client_modules:
+///   serverpod_auth_idp_server:
+///     output: ../my_custom_path
+///     npm_name: '@my-org/auth-idp-ts'
+/// ```
+class ModuleLayoutResolver {
+  ModuleLayoutResolver({
+    required this.appClientOutputDir,
+    required this.config,
+  });
+
+  /// Where the user's APP client is being written. All module clients
+  /// are computed as siblings of this directory (unless overridden).
+  final Directory appClientOutputDir;
+
+  /// The user's [GeneratorConfig] — used to read the optional
+  /// `typescript_client_modules:` override block from generator.yaml.
+  final GeneratorConfig config;
+
+  late final Map<String, _Override> _overrides = _readOverrides();
+
+  ModuleClientLayout resolve(String dartPkgName) {
+    final override = _overrides[dartPkgName];
+    final defaultDirName = _defaultDirName(dartPkgName);
+
+    final outputDir = override?.output != null
+        ? Directory(_resolveOverridePath(override!.output!))
+        : Directory(p.join(appClientOutputDir.parent.path, defaultDirName));
+
+    final npmName = override?.npmName ?? defaultDirName;
+
+    final relativeFromAppClient = p.relative(
+      outputDir.path,
+      from: appClientOutputDir.path,
+    );
+
+    return ModuleClientLayout(
+      dartPkgName: dartPkgName,
+      outputDir: outputDir,
+      npmPackageName: npmName,
+      relativeFromAppClient: relativeFromAppClient,
+    );
+  }
+
+  /// `serverpod_auth_idp_server` → `serverpod_auth_idp_typescript_client`.
+  /// Strips a trailing `_server` if present (matches Serverpod's own
+  /// `<name>_client` convention) and appends `_typescript_client`.
+  String _defaultDirName(String dartPkgName) {
+    final stripped = dartPkgName.endsWith('_server')
+        ? dartPkgName.substring(0, dartPkgName.length - '_server'.length)
+        : dartPkgName;
+    return '${stripped}_typescript_client';
+  }
+
+  String _resolveOverridePath(String overridePath) {
+    if (p.isAbsolute(overridePath)) return overridePath;
+    // Relative paths in the override are interpreted from the app
+    // client's PARENT (so `../foo` works the same way the default does).
+    return p.normalize(
+      p.join(appClientOutputDir.parent.path, overridePath),
+    );
+  }
+
+  Map<String, _Override> _readOverrides() {
+    final yamlFile = File(p.joinAll([
+      ...config.serverPackageDirectoryPathParts,
+      'config',
+      'generator.yaml',
+    ]));
+    if (!yamlFile.existsSync()) return const {};
+
+    final dynamic raw;
+    try {
+      raw = loadYaml(yamlFile.readAsStringSync());
+    } catch (_) {
+      return const {};
+    }
+    if (raw is! YamlMap) return const {};
+    final modulesNode = raw['typescript_client_modules'];
+    if (modulesNode is! YamlMap) return const {};
+
+    final out = <String, _Override>{};
+    for (final entry in modulesNode.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      if (key is! String) continue;
+      if (value is YamlMap) {
+        out[key] = _Override(
+          output: value['output'] as String?,
+          npmName: value['npm_name'] as String?,
+        );
+      } else if (value is String) {
+        // Shorthand: just the npm package name.
+        out[key] = _Override(output: null, npmName: value);
+      }
+    }
+    return out;
+  }
+}
+
+class _Override {
+  _Override({this.output, this.npmName});
+  final String? output;
+  final String? npmName;
+}

--- a/lib/src/discovery/module_discoverer.dart
+++ b/lib/src/discovery/module_discoverer.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// One Serverpod module the user's project depends on.
+class DiscoveredModule {
+  DiscoveredModule({
+    required this.dartPkgName,
+    required this.nickname,
+    required this.serverPkgDir,
+  });
+
+  /// The Dart package name as it appears in pubspec / package_config
+  /// (e.g. `serverpod_auth_idp_server`).
+  final String dartPkgName;
+
+  /// The wire prefix Serverpod uses for class names from this module
+  /// (e.g. `auth`). Read from the module's `config/generator.yaml`.
+  final String nickname;
+
+  /// On-disk root of the module's Dart server package (typically under
+  /// the user's pub-cache).
+  final Directory serverPkgDir;
+
+  @override
+  String toString() => 'DiscoveredModule($dartPkgName, '
+      'nickname=$nickname, dir=${serverPkgDir.path})';
+}
+
+/// Locates every Serverpod module *server* package the project at
+/// [serverDir] depends on, by reading the workspace's
+/// `.dart_tool/package_config.json` and filtering to packages that
+/// declare `type: module` in their `config/generator.yaml`.
+class ModuleDiscoverer {
+  /// Returns an empty list if the project has no module deps.
+  /// Throws [StateError] if `package_config.json` cannot be located —
+  /// that means `dart pub get` hasn't been run yet.
+  static List<DiscoveredModule> discover(Directory serverDir) {
+    final configFile = _locatePackageConfig(serverDir);
+    if (configFile == null) {
+      throw StateError(
+        'No .dart_tool/package_config.json found at or above '
+        '${serverDir.path}. Run `dart pub get` first.',
+      );
+    }
+
+    final config = jsonDecode(configFile.readAsStringSync())
+        as Map<String, dynamic>;
+    final packages = (config['packages'] as List).cast<Map<String, dynamic>>();
+    final configDir = configFile.parent.parent; // walks .dart_tool/
+
+    final modules = <DiscoveredModule>[];
+    for (final pkg in packages) {
+      final name = pkg['name'] as String;
+      final rootUri = pkg['rootUri'] as String;
+      final pkgDir = _resolvePackageDir(rootUri, configDir);
+      if (pkgDir == null) continue;
+
+      final generatorYaml =
+          File(p.join(pkgDir.path, 'config', 'generator.yaml'));
+      if (!generatorYaml.existsSync()) continue;
+
+      final yaml = _safeLoadYaml(generatorYaml);
+      if (yaml is! YamlMap) continue;
+      if (yaml['type'] != 'module') continue;
+
+      final nickname = yaml['nickname'];
+      if (nickname is! String || nickname.isEmpty) continue;
+
+      modules.add(DiscoveredModule(
+        dartPkgName: name,
+        nickname: nickname,
+        serverPkgDir: pkgDir,
+      ));
+    }
+
+    modules.sort((a, b) => a.dartPkgName.compareTo(b.dartPkgName));
+    return modules;
+  }
+
+  /// Walks up from [start] looking for `.dart_tool/package_config.json`.
+  /// Returns null if none found at or above the starting directory.
+  static File? _locatePackageConfig(Directory start) {
+    Directory? cursor = start;
+    while (cursor != null) {
+      final candidate =
+          File(p.join(cursor.path, '.dart_tool', 'package_config.json'));
+      if (candidate.existsSync()) return candidate;
+      final parent = cursor.parent;
+      if (p.equals(parent.path, cursor.path)) return null;
+      cursor = parent;
+    }
+    return null;
+  }
+
+  /// `rootUri` may be absolute (`file:///...`) or relative to the
+  /// directory containing `.dart_tool/`. Returns the resolved directory,
+  /// or null if it doesn't exist.
+  static Directory? _resolvePackageDir(String rootUri, Directory configDir) {
+    final uri = Uri.parse(rootUri);
+    final String absolutePath;
+    if (uri.scheme == 'file') {
+      absolutePath = uri.toFilePath();
+    } else if (uri.scheme.isEmpty) {
+      absolutePath = p.normalize(p.join(configDir.path, uri.path));
+    } else {
+      return null;
+    }
+    final dir = Directory(absolutePath);
+    return dir.existsSync() ? dir : null;
+  }
+
+  static dynamic _safeLoadYaml(File f) {
+    try {
+      return loadYaml(f.readAsStringSync());
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/src/discovery/module_discoverer.dart
+++ b/lib/src/discovery/module_discoverer.dart
@@ -37,6 +37,10 @@ class ModuleDiscoverer {
   /// Returns an empty list if the project has no module deps.
   /// Throws [StateError] if `package_config.json` cannot be located —
   /// that means `dart pub get` hasn't been run yet.
+  ///
+  /// The package whose root resolves to [serverDir] is always
+  /// excluded — when generating a module-typed project we'd otherwise
+  /// rediscover ourselves and try to generate the same client twice.
   static List<DiscoveredModule> discover(Directory serverDir) {
     final configFile = _locatePackageConfig(serverDir);
     if (configFile == null) {
@@ -50,6 +54,7 @@ class ModuleDiscoverer {
         as Map<String, dynamic>;
     final packages = (config['packages'] as List).cast<Map<String, dynamic>>();
     final configDir = configFile.parent.parent; // walks .dart_tool/
+    final selfPath = p.canonicalize(serverDir.path);
 
     final modules = <DiscoveredModule>[];
     for (final pkg in packages) {
@@ -57,6 +62,7 @@ class ModuleDiscoverer {
       final rootUri = pkg['rootUri'] as String;
       final pkgDir = _resolvePackageDir(rootUri, configDir);
       if (pkgDir == null) continue;
+      if (p.canonicalize(pkgDir.path) == selfPath) continue;
 
       final generatorYaml =
           File(p.join(pkgDir.path, 'config', 'generator.yaml'));

--- a/lib/src/discovery/server_directory_finder.dart
+++ b/lib/src/discovery/server_directory_finder.dart
@@ -64,10 +64,13 @@ class ServerDirectoryFinder {
     final dynamic yaml;
     try {
       yaml = loadYaml(pubspec.readAsStringSync());
-    } catch (_) {
-      // An invalid pubspec.yaml on the walk path means "not a Serverpod
-      // server" — keep walking. Don't let a malformed yaml in a parent
-      // directory blow up the whole search.
+    } on YamlException {
+      // Malformed pubspec on the walk path → not a Serverpod server.
+      return false;
+    } on FileSystemException {
+      // Pubspec became unreadable between existsSync() and read.
+      return false;
+    } on FormatException {
       return false;
     }
     if (yaml is! YamlMap) return false;

--- a/lib/src/emit/client_emitter.dart
+++ b/lib/src/emit/client_emitter.dart
@@ -8,7 +8,9 @@ import 'package:serverpod_cli/src/analyzer/dart/definitions.dart'
 import 'package:serverpod_cli/src/config/config.dart' show ModuleConfig;
 import 'package:yaml/yaml.dart';
 
+import '../discovery/module_class_index.dart';
 import 'generated_file_tracker.dart';
+import 'module_import_lines.dart';
 import 'ts_writer.dart';
 
 const _generatedHeader = '''
@@ -28,11 +30,24 @@ class ClientEmitter {
     required this.outputDir,
     required this.tracker,
     required this.config,
+    this.moduleIndex,
+    this.referencedModuleClassNames = const {},
   });
 
   final Directory outputDir;
   final GeneratedFileTracker tracker;
   final GeneratorConfig config;
+
+  /// Index of every class defined in modules this project (transitively)
+  /// depends on. Null for projects with no modules.
+  final ModuleClassIndex? moduleIndex;
+
+  /// The subset of [moduleIndex] class names that this project actually
+  /// references. Drives the cross-package `import` lines emitted at the
+  /// top of `protocol.ts` and the extra cases in
+  /// `deserializeByClassName`. The pipeline has already walked the IR
+  /// to build this set, so we don't recompute it here.
+  final Set<String> referencedModuleClassNames;
 
   bool get _isModule => config.type == PackageType.module;
 
@@ -99,18 +114,21 @@ class ClientEmitter {
     _writeRoot('client.ts', w.toString());
   }
 
-  /// Generates a small wrapper class with one Caller field per declared
-  /// module. Each Caller delegates back through the parent Client. The
-  /// module client packages must already be installed (npm) and importable
-  /// — for v0.1 we emit a stub class because npm publishing of module
-  /// clients lands in v0.2.
+  /// Generates a small wrapper exposing one Caller-shaped field per
+  /// module the project declares. Type-safe, real Caller wiring is
+  /// already covered by the protocol-switch dispatch — module classes
+  /// resolve through cross-package imports — so we keep this wrapper
+  /// as a `unknown`-typed convenience until callers actually request
+  /// a typed namespace surface (tracked by the `Modules.<nickname>`
+  /// stub below).
   void _emitModulesClass(TsWriter w, List<ModuleConfig> modules) {
     w.writeln('/**');
     w.writeln(' * Per-module callers, instantiated lazily by [Client].');
     w.writeln(' *');
-    w.writeln(' * NOTE: v0.1 emits stubs (`unknown`) for module callers.');
-    w.writeln(' * The Caller import path is left as a TODO until v0.2,');
-    w.writeln(' * when module client packages are published to npm.');
+    w.writeln(' * Each field is typed as `unknown` for now; cross-package');
+    w.writeln(' * deserialization already routes through the project');
+    w.writeln(' * Protocol switch, so consumers can reach module types');
+    w.writeln(' * directly via the generated module client packages.');
     w.writeln(' */');
     w.writeln('export class Modules {');
     w.indent(() {
@@ -121,10 +139,7 @@ class ClientEmitter {
       w.writeln('constructor(_parent: r.EndpointCaller) {');
       w.indent(() {
         for (final m in modules) {
-          w.writeln(
-            'this.${m.nickname} = undefined; '
-            '// TODO(v0.2): wire to ${m.nickname}_typescript_client',
-          );
+          w.writeln('this.${m.nickname} = undefined;');
         }
       });
       w.writeln('}');
@@ -183,35 +198,20 @@ class ClientEmitter {
     // bare and prefixed forms so server/client agree across modules.
     final ownPrefix = _isModule ? _readSelfNickname() : null;
 
-    final entries = <_ClassEntry>[];
-    for (final m in models) {
-      if (m is ModelClassDefinition) {
-        entries.add(_ClassEntry(
-          name: m.className,
-          isSealed: m.isSealed,
-          receiver: m.isSealed ? '${m.className}Base' : m.className,
-        ));
-      } else if (m is ExceptionClassDefinition) {
-        entries.add(_ClassEntry(
-          name: m.className,
-          isSealed: false,
-          receiver: m.className,
-        ));
-      } else if (m is EnumDefinition) {
-        entries.add(_ClassEntry(
-          name: m.className,
-          isSealed: false,
-          receiver: '${m.className}Codec',
-        ));
-      }
-    }
-    entries.sort((a, b) => a.name.compareTo(b.name));
+    final entries = <_ClassEntry>[
+      for (final m in models) ..._projectEntriesFor(m),
+      ..._moduleEntries(),
+    ]..sort((a, b) => a.name.compareTo(b.name));
+    final moduleImportLines = _moduleImportLines();
 
     final w = TsWriter()
       ..writeRaw(_generatedHeader)
       ..writeln("import * as r from './runtime/index.js';")
-      ..writeln("import * as p from './protocol/index.js';")
-      ..blankLine();
+      ..writeln("import * as p from './protocol/index.js';");
+    for (final line in moduleImportLines) {
+      w.writeln(line);
+    }
+    w.blankLine();
 
     w.writeln('export class Protocol extends r.SerializationManager {');
     w.indent(() {
@@ -248,7 +248,7 @@ class ClientEmitter {
         w.writeln('switch (className) {');
         w.indent(() {
           for (final e in entries) {
-            w.writeln("case '${e.name}': return p.${e.receiver}.fromJson(data);");
+            w.writeln("case '${e.name}': return ${e.receiver}.fromJson(data);");
           }
           w.writeln('default: return undefined;');
         });
@@ -283,6 +283,95 @@ class ClientEmitter {
   String _filenameStem(String name) =>
       name.replaceAllMapped(RegExp(r'[A-Z]'), (m) => '_${m[0]!.toLowerCase()}');
 
+  /// Builds the dispatch entries for a single project-defined model.
+  /// Returns an empty list for unsupported model kinds so the caller
+  /// can splat results unconditionally.
+  List<_ClassEntry> _projectEntriesFor(SerializableModelDefinition m) {
+    if (m is ModelClassDefinition) {
+      return [
+        _ClassEntry(
+          name: m.className,
+          receiver: _receiverFor(
+            name: m.className,
+            prefix: 'p.',
+            isEnum: false,
+            isSealed: m.isSealed,
+          ),
+        ),
+      ];
+    }
+    if (m is ExceptionClassDefinition) {
+      return [
+        _ClassEntry(
+          name: m.className,
+          receiver: _receiverFor(
+            name: m.className,
+            prefix: 'p.',
+            isEnum: false,
+            isSealed: false,
+          ),
+        ),
+      ];
+    }
+    if (m is EnumDefinition) {
+      return [
+        _ClassEntry(
+          name: m.className,
+          receiver: _receiverFor(
+            name: m.className,
+            prefix: 'p.',
+            isEnum: true,
+            isSealed: false,
+          ),
+        ),
+      ];
+    }
+    return const [];
+  }
+
+  /// Dispatch entries for every referenced module-defined class —
+  /// imported under bare names so calling `<Name>.fromJson(...)`
+  /// resolves through the matching `import { Name } from '<pkg>'` line.
+  List<_ClassEntry> _moduleEntries() {
+    final mi = moduleIndex;
+    if (mi == null || referencedModuleClassNames.isEmpty) return const [];
+    return [
+      for (final name in referencedModuleClassNames)
+        if (mi.layoutFor(name) != null)
+          _ClassEntry(
+            name: name,
+            receiver: _receiverFor(
+              name: name,
+              prefix: '',
+              isEnum: mi.isEnum(name),
+              isSealed: mi.isSealed(name),
+            ),
+          ),
+    ];
+  }
+
+  /// `import { ... } from '<pkg>';` lines for every module package the
+  /// protocol switch dispatches into. Empty when there are no module
+  /// references — keeps the no-modules emission byte-identical to v0.1.
+  List<String> _moduleImportLines() {
+    final mi = moduleIndex;
+    if (mi == null) return const [];
+    return ModuleImportLines(mi).forClassNames(referencedModuleClassNames);
+  }
+
+  /// Single source of truth for "what symbol do I call `.fromJson` on
+  /// for a given name?". Used by both project and module entry paths.
+  String _receiverFor({
+    required String name,
+    required String prefix,
+    required bool isEnum,
+    required bool isSealed,
+  }) {
+    if (isEnum) return '$prefix${name}Codec';
+    if (isSealed) return '$prefix${name}Base';
+    return '$prefix$name';
+  }
+
   /// Reads the top-level `nickname:` key from this project's
   /// `config/generator.yaml`. Required for module-type projects so the
   /// emitter can name the Caller and the wire prefix correctly.
@@ -310,13 +399,12 @@ class ClientEmitter {
 }
 
 class _ClassEntry {
-  _ClassEntry({
-    required this.name,
-    required this.isSealed,
-    required this.receiver,
-  });
+  _ClassEntry({required this.name, required this.receiver});
 
+  /// The wire-form `__className__` (after stripping any `module.` prefix).
   final String name;
-  final bool isSealed;
+
+  /// The full TS expression to call `.fromJson(...)` on, including any
+  /// import-alias prefix (`p.` for project-local, bare for module).
   final String receiver;
 }

--- a/lib/src/emit/endpoint_emitter.dart
+++ b/lib/src/emit/endpoint_emitter.dart
@@ -5,7 +5,9 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 
+import '../analyzer/ir_walker.dart';
 import 'generated_file_tracker.dart';
+import 'module_import_lines.dart';
 import 'ts_type_mapper.dart';
 import 'ts_writer.dart';
 
@@ -27,6 +29,9 @@ class EndpointEmitter {
   final Directory outputDir;
   final GeneratedFileTracker tracker;
   final TsTypeMapper mapper;
+
+  late final ModuleImportLines _moduleImports =
+      ModuleImportLines(mapper.moduleIndex);
 
   /// Emits every concrete endpoint in [endpoints]. Returns the list of
   /// emitted basenames (without the `.ts` suffix), in alphabetical order.
@@ -54,8 +59,13 @@ class EndpointEmitter {
     final w = TsWriter()
       ..writeRaw(_generatedHeader)
       ..writeln("import * as r from '../runtime/index.js';")
-      ..writeln("import * as p from '../protocol/index.js';")
-      ..blankLine();
+      ..writeln("import * as p from '../protocol/index.js';");
+    final moduleImports =
+        _moduleImports.forTypes(IrWalker.endpointTypeRefs(ep));
+    for (final line in moduleImports) {
+      w.writeln(line);
+    }
+    w.blankLine();
 
     final className = 'Endpoint${_pascalCase(ep.name)}';
 

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 
 import 'generated_file_tracker.dart';
+import 'module_import_lines.dart';
 import 'ts_type_mapper.dart';
 import 'ts_writer.dart';
 
@@ -25,6 +26,21 @@ class ModelEmitter {
   final Directory outputDir;
   final GeneratedFileTracker tracker;
   final TsTypeMapper mapper;
+
+  late final ModuleImportLines _moduleImports =
+      ModuleImportLines(mapper.moduleIndex);
+
+  /// Appends one cross-package `import` line per module package
+  /// referenced by [fields] to [w]. Shared between `_emitClass` and
+  /// `_emitException` so the two paths can't drift.
+  void _writeModuleImports(
+    TsWriter w,
+    List<SerializableModelFieldDefinition> fields,
+  ) {
+    for (final line in _moduleImports.forTypes(fields.map((f) => f.type))) {
+      w.writeln(line);
+    }
+  }
 
   /// Class names emitted as TS enums. Used for cross-file imports —
   /// enum imports also need to bring in `<Name>Codec`.
@@ -250,6 +266,7 @@ class ModelEmitter {
     for (final line in imports) {
       w.writeln(line);
     }
+    _writeModuleImports(w, fields);
     w.blankLine();
 
     w.docComment(model.documentation?.join('\n'));
@@ -378,6 +395,7 @@ class ModelEmitter {
     for (final line in imports) {
       w.writeln(line);
     }
+    _writeModuleImports(w, fields);
     w.blankLine();
 
     w.docComment(model.documentation?.join('\n'));

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -135,8 +135,13 @@ class ModelEmitter {
   }
 
   /// Walks a [TypeDefinition] recursively (descending into generics)
-  /// and yields every project-class name referenced. Skips primitives,
-  /// collections (List/Set/Map/Future/Stream), and any self-reference.
+  /// and adds every project-class name referenced to [out]. Primitives
+  /// and collection wrappers are skipped because they're not in
+  /// [_allClassNames].
+  ///
+  /// Self-references ARE collected here; [_buildImportLines] strips the
+  /// owner's own className before writing the import lines so the file
+  /// doesn't import itself.
   void _collectReferencedProjectTypes(
     TypeDefinition type,
     Set<String> out,

--- a/lib/src/emit/module_import_lines.dart
+++ b/lib/src/emit/module_import_lines.dart
@@ -1,0 +1,88 @@
+// ignore_for_file: implementation_imports
+import 'package:serverpod_cli/analyzer.dart';
+
+import '../discovery/module_class_index.dart';
+
+/// Builds the cross-PACKAGE `import { ... } from '<pkg>';` lines a
+/// generated TS file needs in order to reach module-defined types.
+///
+/// The [TsTypeMapper] emits bare TS names for module-defined classes
+/// (no `p.` prefix); this helper walks a set of type definitions,
+/// groups every referenced module class by its npm package, and
+/// produces one alphabetised import line per package — collapsing
+/// multiple references to a single module into a single statement.
+class ModuleImportLines {
+  ModuleImportLines(this._index);
+
+  final ModuleClassIndex _index;
+
+  /// Returns one import line per module package referenced by [types]
+  /// (recursively through generics). Lines are sorted by package name;
+  /// symbols within each line are sorted by class name.
+  List<String> forTypes(Iterable<TypeDefinition> types) {
+    final referenced = <String>{};
+    for (final t in types) {
+      _collect(t, referenced);
+    }
+    return forClassNames(referenced);
+  }
+
+  /// Returns one import line per module package referenced by
+  /// [classNames] — same grouping/sorting rules as [forTypes], but
+  /// skips the type-definition walk for callers that already hold a
+  /// flat name set (e.g. the protocol-switch emitter).
+  List<String> forClassNames(Iterable<String> classNames) {
+    final byPackage = <String, Set<String>>{};
+    for (final name in classNames) {
+      final layout = _index.layoutFor(name);
+      if (layout == null) continue;
+      byPackage
+          .putIfAbsent(layout.npmPackageName, () => <String>{})
+          .add(name);
+    }
+
+    final packages = byPackage.keys.toList()..sort();
+    return [
+      for (final pkg in packages)
+        "import { ${symbolsFor(byPackage[pkg]!).join(', ')} } from '$pkg';",
+    ];
+  }
+
+  /// The TS symbols a generated file must import for every name in
+  /// [classNames]. Mirrors what [TsTypeMapper] references at the use
+  /// site:
+  ///   plain class    → `Name`
+  ///   exception      → `Name`
+  ///   sealed base    → `Name` (the union alias) + `NameBase` (dispatcher)
+  ///   enum           → `Name` + `NameCodec`
+  ///
+  /// Names that aren't in the underlying [ModuleClassIndex] are
+  /// silently skipped — callers should pre-filter, but this lets the
+  /// helper double as a defensive boundary.
+  List<String> symbolsFor(Iterable<String> classNames) {
+    final sorted = classNames.toList()..sort();
+    final out = <String>[];
+    for (final name in sorted) {
+      if (_index.layoutFor(name) == null) continue;
+      if (_index.isEnum(name)) {
+        out
+          ..add(name)
+          ..add('${name}Codec');
+      } else if (_index.isSealed(name)) {
+        out
+          ..add(name)
+          ..add('${name}Base');
+      } else {
+        out.add(name);
+      }
+    }
+    return out;
+  }
+
+  void _collect(TypeDefinition type, Set<String> out) {
+    if (_index.layoutFor(type.className) != null) out.add(type.className);
+    for (final g in type.generics) {
+      _collect(g, out);
+    }
+  }
+}

--- a/lib/src/emit/output_paths.dart
+++ b/lib/src/emit/output_paths.dart
@@ -13,7 +13,11 @@ import 'package:yaml/yaml.dart';
 ///   2. `typescript_client_package_path` in `config/generator.yaml`.
 ///   3. Sibling of the server package: `<server>/../<name>_typescript_client/`.
 class OutputPaths {
-  OutputPaths._({
+  /// Construct directly when caller already knows the explicit dir +
+  /// pkg name (used by [GenerationPipeline] for module clients);
+  /// otherwise prefer [resolve] which derives both from a
+  /// [GeneratorConfig].
+  OutputPaths({
     required this.outputDir,
     required this.packageName,
   });
@@ -32,7 +36,7 @@ class OutputPaths {
     final outputPath = explicitOutput ??
         _readFromGeneratorYaml(config) ??
         _defaultPath(config);
-    return OutputPaths._(
+    return OutputPaths(
       outputDir: Directory(outputPath),
       packageName: '${config.name}_typescript_client',
     );

--- a/lib/src/emit/scaffold_emitter.dart
+++ b/lib/src/emit/scaffold_emitter.dart
@@ -17,6 +17,7 @@ class ScaffoldEmitter {
     required this.outputPaths,
     required this.tracker,
     this.additionalBarrelExports = const [],
+    this.moduleDependencies = const {},
   });
 
   final OutputPaths outputPaths;
@@ -25,6 +26,11 @@ class ScaffoldEmitter {
   /// Extra re-exports the barrel `src/index.ts` should include beyond
   /// the runtime — e.g. `./protocol/index.js` once model emission lands.
   final List<String> additionalBarrelExports;
+
+  /// Maps npm package name → version-or-url string (typically
+  /// `file:..` for sibling-generated module clients). Each entry
+  /// becomes one `dependencies:` line in the generated `package.json`.
+  final Map<String, String> moduleDependencies;
 
   Future<void> emit() async {
     outputPaths.outputDir.createSync(recursive: true);
@@ -105,6 +111,9 @@ class ScaffoldEmitter {
   }
 
   String _packageJsonContent() {
+    final depsBlock = moduleDependencies.isEmpty
+        ? ''
+        : '  "dependencies": ${_formatDeps(moduleDependencies)},\n';
     return '''
 {
   "name": "${outputPaths.packageName}",
@@ -124,11 +133,21 @@ class ScaffoldEmitter {
     "build": "tsc",
     "typecheck": "tsc --noEmit"
   },
-  "devDependencies": {
+$depsBlock  "devDependencies": {
     "typescript": "^5.4.0"
   }
 }
 ''';
+  }
+
+  /// Inline the deps map as a stable, alphabetised JSON object.
+  String _formatDeps(Map<String, String> deps) {
+    final keys = deps.keys.toList()..sort();
+    final lines = <String>[];
+    for (final k in keys) {
+      lines.add('    "$k": "${deps[k]}"');
+    }
+    return '{\n${lines.join(',\n')}\n  }';
   }
 
   String _tsconfigContent() {

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -204,42 +204,33 @@ class TsTypeMapper {
   TsTypeRef _mapModelOrEnum(TypeDefinition type) {
     final className = type.className;
 
-    // 1. Module-defined type? Emit the bare TS name; the emitter is
+    // 1. Local project types win over the module index. If a name
+    // collides — say, an app model with the same className as a
+    // module class — the local definition is the source of truth and
+    // we must not emit cross-package imports for it. (When generating
+    // a module client, the project's own classes ARE in the module
+    // index too; this ordering keeps that case from self-importing.)
+    final isLocal = projectClassNames.isEmpty ||
+        projectClassNames.contains(className);
+    if (isLocal) return _mapLocalProjectType(className);
+
+    // 2. Module-defined type? Emit the bare TS name; the emitter is
     // responsible for the matching `import { Name } from '<pkg>';`
     // line at the top of the file.
     if (moduleIndex.layoutFor(className) != null) {
-      if (moduleIndex.isEnum(className)) {
-        return TsTypeRef(
-          tsType: className,
-          toJsonExpr: (v) => '${className}Codec.toJson($v)',
-          fromJsonExpr: (v) => '${className}Codec.fromJson($v)',
-        );
-      }
-      final receiver = moduleIndex.isSealed(className)
-          ? '${className}Base'
-          : className;
-      return TsTypeRef(
-        tsType: className,
-        toJsonExpr: (v) => '$v.toJson()',
-        fromJsonExpr: (v) =>
-            '$receiver.fromJson($v as Record<string, unknown>)',
-      );
+      return _mapModuleType(className);
     }
 
-    // 2. Foreign + unknown — neither local nor in any module dep.
+    // 3. Foreign + unknown — neither local nor in any module dep.
     // Falls back to `unknown` so the package still compiles.
-    if (projectClassNames.isNotEmpty &&
-        !projectClassNames.contains(className)) {
-      return TsTypeRef(
-        tsType: 'unknown /* TODO: unknown type $className */',
-        toJsonExpr: (v) => '$v as unknown',
-        fromJsonExpr: (v) => '$v as unknown',
-      );
-    }
+    return TsTypeRef(
+      tsType: 'unknown /* TODO: unknown type $className */',
+      toJsonExpr: (v) => '$v as unknown',
+      fromJsonExpr: (v) => '$v as unknown',
+    );
+  }
 
-    // 3. Local project type. Apply modelPrefix so endpoint files can
-    // namespace these (`p.UserProfile`) while model files use bare
-    // names.
+  TsTypeRef _mapLocalProjectType(String className) {
     final qualifiedType = '$modelPrefix$className';
 
     if (enumClassNames.contains(className)) {
@@ -259,6 +250,24 @@ class TsTypeMapper {
       toJsonExpr: (v) => '$v.toJson()',
       fromJsonExpr: (v) =>
           '$fromJsonReceiver.fromJson($v as Record<string, unknown>)',
+    );
+  }
+
+  TsTypeRef _mapModuleType(String className) {
+    if (moduleIndex.isEnum(className)) {
+      return TsTypeRef(
+        tsType: className,
+        toJsonExpr: (v) => '${className}Codec.toJson($v)',
+        fromJsonExpr: (v) => '${className}Codec.fromJson($v)',
+      );
+    }
+    final receiver =
+        moduleIndex.isSealed(className) ? '${className}Base' : className;
+    return TsTypeRef(
+      tsType: className,
+      toJsonExpr: (v) => '$v.toJson()',
+      fromJsonExpr: (v) =>
+          '$receiver.fromJson($v as Record<string, unknown>)',
     );
   }
 

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -210,9 +210,14 @@ class TsTypeMapper {
     // we must not emit cross-package imports for it. (When generating
     // a module client, the project's own classes ARE in the module
     // index too; this ordering keeps that case from self-importing.)
-    final isLocal = projectClassNames.isEmpty ||
-        projectClassNames.contains(className);
-    if (isLocal) return _mapLocalProjectType(className);
+    //
+    // We deliberately do NOT default-to-local when the set is empty:
+    // a project with zero local models that calls module endpoints
+    // would otherwise produce `p.AuthSuccess.fromJson(...)` and break
+    // tsc, since there's no local protocol barrel to namespace into.
+    if (projectClassNames.contains(className)) {
+      return _mapLocalProjectType(className);
+    }
 
     // 2. Module-defined type? Emit the bare TS name; the emitter is
     // responsible for the matching `import { Name } from '<pkg>';`

--- a/lib/src/emit/ts_type_mapper.dart
+++ b/lib/src/emit/ts_type_mapper.dart
@@ -1,6 +1,8 @@
 // ignore_for_file: implementation_imports
 import 'package:serverpod_cli/analyzer.dart';
 
+import '../discovery/module_class_index.dart';
+
 /// A TypeScript type reference plus the JSON conversion expressions that
 /// turn a value of that type into wire form (and back).
 class TsTypeRef {
@@ -37,9 +39,11 @@ class TsTypeMapper {
     Set<String>? sealedClassNames,
     Set<String>? enumClassNames,
     Set<String>? projectClassNames,
+    ModuleClassIndex? moduleIndex,
   })  : sealedClassNames = sealedClassNames ?? const {},
         enumClassNames = enumClassNames ?? const {},
-        projectClassNames = projectClassNames ?? const {};
+        projectClassNames = projectClassNames ?? const {},
+        moduleIndex = moduleIndex ?? ModuleClassIndex.empty;
 
   final String modelPrefix;
 
@@ -55,12 +59,15 @@ class TsTypeMapper {
   /// instead of `<value>.toJson()` / `<Name>.fromJson(json)`.
   final Set<String> enumClassNames;
 
-  /// Every class name emitted as part of THIS project (sealed, enum,
-  /// regular class, exception). Anything not in here is a foreign
-  /// type — typically defined in a Serverpod module the project
-  /// depends on. v0.1.x stubs foreign types as `unknown`; v0.2 will
-  /// emit a real cross-package import.
+  /// Every class name emitted as part of THIS project. Anything not
+  /// in here is foreign — either resolved via [moduleIndex] (a real
+  /// module dep) or genuinely unknown (`unknown` fallback).
   final Set<String> projectClassNames;
+
+  /// Index of every class name defined in modules the project depends
+  /// on. The mapper emits the bare TS name for these; the surrounding
+  /// emitter is responsible for the matching `import` line.
+  final ModuleClassIndex moduleIndex;
 
   TsTypeRef map(TypeDefinition type) {
     final base = _mapInner(type);
@@ -123,19 +130,12 @@ class TsTypeMapper {
         return _mapMap(type);
       case 'Future':
       case 'Stream':
-        // Streaming params/returns are stubbed by the endpoint emitter,
-        // so the precise type doesn't matter at the call site — but we
-        // still need a TS placeholder that compiles.
         return TsTypeRef(
           tsType: 'unknown',
           toJsonExpr: (v) => v,
           fromJsonExpr: (v) => v,
         );
       case 'void':
-        // Endpoint emitter inspects `tsReturnInner == 'void'` and emits
-        // `() => undefined as void` for the decoder, so the to/from
-        // expressions here are unreachable in practice. Keep them
-        // identity-passes for safety.
         return TsTypeRef(
           tsType: 'void',
           toJsonExpr: (v) => v,
@@ -202,27 +202,48 @@ class TsTypeMapper {
   }
 
   TsTypeRef _mapModelOrEnum(TypeDefinition type) {
-    final qualifiedType = '$modelPrefix${type.className}';
+    final className = type.className;
 
-    // Foreign type — typically defined in a Serverpod module the
-    // project depends on (e.g. AuthSuccess from serverpod_auth_idp).
-    // v0.1.x falls back to `unknown` so the package compiles; v0.2
-    // will emit real `import type { ... } from '<module-ts-pkg>';`
-    // statements based on `TypeDefinition.url`.
-    if (projectClassNames.isNotEmpty &&
-        !projectClassNames.contains(type.className)) {
+    // 1. Module-defined type? Emit the bare TS name; the emitter is
+    // responsible for the matching `import { Name } from '<pkg>';`
+    // line at the top of the file.
+    if (moduleIndex.layoutFor(className) != null) {
+      if (moduleIndex.isEnum(className)) {
+        return TsTypeRef(
+          tsType: className,
+          toJsonExpr: (v) => '${className}Codec.toJson($v)',
+          fromJsonExpr: (v) => '${className}Codec.fromJson($v)',
+        );
+      }
+      final receiver = moduleIndex.isSealed(className)
+          ? '${className}Base'
+          : className;
       return TsTypeRef(
-        // The `unknown` cast keeps tsc happy and surfaces the gap to
-        // users via the IDE's hover.
-        tsType: 'unknown /* TODO(v0.2): module type ${type.className} */',
+        tsType: className,
+        toJsonExpr: (v) => '$v.toJson()',
+        fromJsonExpr: (v) =>
+            '$receiver.fromJson($v as Record<string, unknown>)',
+      );
+    }
+
+    // 2. Foreign + unknown — neither local nor in any module dep.
+    // Falls back to `unknown` so the package still compiles.
+    if (projectClassNames.isNotEmpty &&
+        !projectClassNames.contains(className)) {
+      return TsTypeRef(
+        tsType: 'unknown /* TODO: unknown type $className */',
         toJsonExpr: (v) => '$v as unknown',
         fromJsonExpr: (v) => '$v as unknown',
       );
     }
 
-    if (enumClassNames.contains(type.className)) {
-      // Enums use a sibling `<Name>Codec` object for both directions.
-      final codec = '$modelPrefix${type.className}Codec';
+    // 3. Local project type. Apply modelPrefix so endpoint files can
+    // namespace these (`p.UserProfile`) while model files use bare
+    // names.
+    final qualifiedType = '$modelPrefix$className';
+
+    if (enumClassNames.contains(className)) {
+      final codec = '$modelPrefix${className}Codec';
       return TsTypeRef(
         tsType: qualifiedType,
         toJsonExpr: (v) => '$codec.toJson($v)',
@@ -230,11 +251,8 @@ class TsTypeMapper {
       );
     }
 
-    // Sealed bases route `fromJson` through `<Name>Base` (the abstract
-    // dispatcher); the type itself is the bare union alias. Plain
-    // classes / exceptions use `<Name>.fromJson(...)`.
-    final fromJsonReceiver = sealedClassNames.contains(type.className)
-        ? '$modelPrefix${type.className}Base'
+    final fromJsonReceiver = sealedClassNames.contains(className)
+        ? '$modelPrefix${className}Base'
         : qualifiedType;
     return TsTypeRef(
       tsType: qualifiedType,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.1.4
+version: 0.2.0
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 

--- a/test/client_emitter_modules_test.dart
+++ b/test/client_emitter_modules_test.dart
@@ -1,0 +1,190 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_typescript_bridge/src/discovery/module_class_index.dart';
+import 'package:serverpod_typescript_bridge/src/discovery/module_client_layout.dart';
+import 'package:serverpod_typescript_bridge/src/emit/client_emitter.dart';
+import 'package:serverpod_typescript_bridge/src/emit/generated_file_tracker.dart';
+import 'package:test/test.dart';
+
+/// Exercises the ClientEmitter ↔ ModuleClassIndex boundary added in
+/// v0.2 — proves that the protocol switch dispatches module-defined
+/// classes through bare imported symbols, and that the no-modules
+/// fallback path still emits byte-equivalent v0.1 output.
+///
+/// Loads a real [GeneratorConfig] from the sample_server fixture so
+/// tests don't have to hand-roll the (large) config object.
+void main() {
+  late GeneratorConfig sampleServerConfig;
+
+  setUpAll(() async {
+    // GeneratorConfig.load consults the experimental-features singleton;
+    // mirror what the production CLI does before invoking the loader.
+    CommandLineExperimentalFeatures.initialize(const []);
+    sampleServerConfig = await GeneratorConfig.load(
+      serverRootDir: 'test/fixtures/sample_server/sample_server',
+      interactive: false,
+    );
+  });
+
+  ModuleClientLayout layoutFor(String dartPkg, String npmName) {
+    return ModuleClientLayout(
+      dartPkgName: dartPkg,
+      outputDir: Directory('/tmp/$npmName'),
+      npmPackageName: npmName,
+      relativeFromAppClient: '../$npmName',
+    );
+  }
+
+  Future<String> emitAndReadProtocol({
+    ModuleClassIndex? moduleIndex,
+    Set<String> referencedModuleClassNames = const {},
+  }) async {
+    final tempOut = Directory.systemTemp.createTempSync('sptb_ce_');
+    addTearDown(() {
+      if (tempOut.existsSync()) tempOut.deleteSync(recursive: true);
+    });
+
+    final tracker = GeneratedFileTracker([
+      Directory(p.join(tempOut.path, 'src')),
+    ]);
+    ClientEmitter(
+      outputDir: tempOut,
+      tracker: tracker,
+      config: sampleServerConfig,
+      moduleIndex: moduleIndex,
+      referencedModuleClassNames: referencedModuleClassNames,
+    ).emit(endpoints: const [], models: const []);
+
+    final protocolFile = File(p.join(tempOut.path, 'src', 'protocol.ts'));
+    expect(protocolFile.existsSync(), isTrue,
+        reason: 'ClientEmitter should always write protocol.ts');
+    return protocolFile.readAsString();
+  }
+
+  group('ClientEmitter — no module deps', () {
+    test('emits no cross-package import lines and no module switch cases',
+        () async {
+      final src = await emitAndReadProtocol();
+
+      expect(
+        src,
+        isNot(contains("from '../")),
+        reason:
+            'no-modules path must not emit any cross-package import lines',
+      );
+      expect(
+        RegExp(r"^import \{ .+ \} from '[^./]").allMatches(src).length,
+        0,
+        reason: 'no bare module-package imports should appear',
+      );
+      expect(src, contains('switch (className)'));
+      expect(src, contains('default: return undefined;'));
+    });
+
+    test('null moduleIndex behaves identically to an empty referenced set',
+        () async {
+      final withNull = await emitAndReadProtocol();
+      final withEmpty = await emitAndReadProtocol(
+        moduleIndex: ModuleClassIndex.empty,
+      );
+      expect(withNull, equals(withEmpty));
+    });
+  });
+
+  group('ClientEmitter — with referenced module classes', () {
+    test('emits one import line per module package, alphabetised', () async {
+      final auth = layoutFor('auth_server', 'auth_typescript_client');
+      final chat = layoutFor('chat_server', 'chat_typescript_client');
+      final index = ModuleClassIndex.forTesting(
+        classToLayout: {'AuthSuccess': auth, 'ChatMessage': chat},
+      );
+
+      final src = await emitAndReadProtocol(
+        moduleIndex: index,
+        referencedModuleClassNames: {'AuthSuccess', 'ChatMessage'},
+      );
+
+      expect(
+        src,
+        contains("import { AuthSuccess } from 'auth_typescript_client';"),
+      );
+      expect(
+        src,
+        contains("import { ChatMessage } from 'chat_typescript_client';"),
+      );
+      // Sort order: auth before chat.
+      expect(
+        src.indexOf('auth_typescript_client'),
+        lessThan(src.indexOf('chat_typescript_client')),
+      );
+    });
+
+    test('protocol switch dispatches module classes through bare receivers',
+        () async {
+      final auth = layoutFor('auth_server', 'auth_ts');
+      final index = ModuleClassIndex.forTesting(
+        classToLayout: {
+          'AuthSuccess': auth,
+          'AuthRole': auth,
+          'AuthAnimal': auth,
+        },
+        enumClassNames: {'AuthRole'},
+        sealedClassNames: {'AuthAnimal'},
+      );
+
+      final src = await emitAndReadProtocol(
+        moduleIndex: index,
+        referencedModuleClassNames: {
+          'AuthSuccess',
+          'AuthRole',
+          'AuthAnimal',
+        },
+      );
+
+      expect(
+        src,
+        contains("case 'AuthSuccess': return AuthSuccess.fromJson(data);"),
+      );
+      expect(
+        src,
+        contains("case 'AuthRole': return AuthRoleCodec.fromJson(data);"),
+      );
+      expect(
+        src,
+        contains("case 'AuthAnimal': return AuthAnimalBase.fromJson(data);"),
+      );
+      // Sealed dispatcher and enum codec are also brought in as imports.
+      expect(
+        src,
+        contains(
+          "import { AuthAnimal, AuthAnimalBase, AuthRole, AuthRoleCodec, "
+          "AuthSuccess } from 'auth_ts';",
+        ),
+      );
+    });
+
+    test(
+        'referencedModuleClassNames not in the index are silently skipped — '
+        'no broken case label, no broken import', () async {
+      final auth = layoutFor('auth_server', 'auth_ts');
+      final index = ModuleClassIndex.forTesting(
+        classToLayout: {'AuthSuccess': auth},
+      );
+
+      final src = await emitAndReadProtocol(
+        moduleIndex: index,
+        referencedModuleClassNames: {'AuthSuccess', 'GhostType'},
+      );
+
+      expect(
+        src,
+        contains("case 'AuthSuccess': return AuthSuccess.fromJson(data);"),
+      );
+      expect(src, isNot(contains('GhostType')));
+    });
+  });
+}

--- a/test/client_emitter_modules_test.dart
+++ b/test/client_emitter_modules_test.dart
@@ -35,7 +35,6 @@ void main() {
       dartPkgName: dartPkg,
       outputDir: Directory('/tmp/$npmName'),
       npmPackageName: npmName,
-      relativeFromAppClient: '../$npmName',
     );
   }
 

--- a/test/module_client_layout_test.dart
+++ b/test/module_client_layout_test.dart
@@ -43,10 +43,6 @@ void main() {
           reason: 'module client should sit next to the app client',
         );
         expect(layout.npmPackageName, 'serverpod_auth_idp_typescript_client');
-        expect(
-          layout.relativeFromAppClient,
-          '../serverpod_auth_idp_typescript_client',
-        );
       },
     );
 

--- a/test/module_client_layout_test.dart
+++ b/test/module_client_layout_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_typescript_bridge/src/discovery/module_client_layout.dart';
+import 'package:test/test.dart';
+
+import 'protocol_loader_test_helper.dart';
+
+void main() {
+  group('ModuleLayoutResolver', () {
+    late Directory tempAppClientOut;
+
+    setUp(() {
+      tempAppClientOut =
+          Directory.systemTemp.createTempSync('sptb_layout_app_');
+    });
+
+    tearDown(() {
+      if (tempAppClientOut.existsSync()) {
+        tempAppClientOut.deleteSync(recursive: true);
+      }
+    });
+
+    test(
+      'default: <module>_server → sibling dir <module>_typescript_client',
+      () async {
+        final config = await loadFixtureConfig();
+        final resolver = ModuleLayoutResolver(
+          appClientOutputDir: tempAppClientOut,
+          config: config,
+        );
+        final layout = resolver.resolve('serverpod_auth_idp_server');
+        expect(
+          p.basename(layout.outputDir.path),
+          'serverpod_auth_idp_typescript_client',
+        );
+        expect(
+          p.equals(
+            layout.outputDir.parent.path,
+            tempAppClientOut.parent.path,
+          ),
+          isTrue,
+          reason: 'module client should sit next to the app client',
+        );
+        expect(layout.npmPackageName, 'serverpod_auth_idp_typescript_client');
+        expect(
+          layout.relativeFromAppClient,
+          '../serverpod_auth_idp_typescript_client',
+        );
+      },
+    );
+
+    test(
+      'pkg names without _server suffix are appended directly',
+      () async {
+        final config = await loadFixtureConfig();
+        final resolver = ModuleLayoutResolver(
+          appClientOutputDir: tempAppClientOut,
+          config: config,
+        );
+        final layout = resolver.resolve('weird_module_name');
+        expect(
+          p.basename(layout.outputDir.path),
+          'weird_module_name_typescript_client',
+        );
+      },
+    );
+  });
+}

--- a/test/module_discoverer_test.dart
+++ b/test/module_discoverer_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_typescript_bridge/src/discovery/module_discoverer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempRoot;
+
+  setUp(() {
+    tempRoot = Directory.systemTemp.createTempSync('sptb_module_disc_');
+  });
+
+  tearDown(() {
+    if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+  });
+
+  /// Builds a synthetic Serverpod-shaped workspace:
+  ///   <tempRoot>/
+  ///     .dart_tool/package_config.json   (entries for `app_server` + every module)
+  ///     app_server/                       (the user's app server)
+  ///     <each-module>/
+  ///       config/generator.yaml          (with type + nickname)
+  void scaffoldWorkspace({
+    required List<({String name, String type, String? nickname})> packages,
+  }) {
+    final entries = StringBuffer('[');
+    for (var i = 0; i < packages.length; i++) {
+      final pkg = packages[i];
+      final pkgDir = Directory(p.join(tempRoot.path, pkg.name));
+      pkgDir.createSync(recursive: true);
+      if (pkg.type == 'module' || pkg.type == 'server') {
+        final yaml = StringBuffer()
+          ..writeln('type: ${pkg.type}');
+        if (pkg.nickname != null) yaml.writeln('nickname: ${pkg.nickname}');
+        File(p.join(pkgDir.path, 'config', 'generator.yaml'))
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(yaml.toString());
+      }
+      entries.write(
+        '{"name": "${pkg.name}", '
+        '"rootUri": "file://${pkgDir.path}", '
+        '"packageUri": "lib/", '
+        '"languageVersion": "3.0"}',
+      );
+      if (i + 1 < packages.length) entries.write(',');
+    }
+    entries.write(']');
+    final configDir = Directory(p.join(tempRoot.path, '.dart_tool'))
+      ..createSync(recursive: true);
+    File(p.join(configDir.path, 'package_config.json')).writeAsStringSync(
+      '{"configVersion": 2, "packages": $entries}',
+    );
+  }
+
+  test('returns empty list when project has no module deps', () {
+    scaffoldWorkspace(packages: [
+      (name: 'app_server', type: 'server', nickname: null),
+      (name: 'plain_dep', type: 'none', nickname: null),
+    ]);
+    final modules = ModuleDiscoverer.discover(
+      Directory(p.join(tempRoot.path, 'app_server')),
+    );
+    expect(modules, isEmpty);
+  });
+
+  test('detects module-type packages and skips non-module packages', () {
+    scaffoldWorkspace(packages: [
+      (name: 'app_server', type: 'server', nickname: null),
+      (name: 'serverpod_auth_idp_server', type: 'module', nickname: 'auth'),
+      (name: 'serverpod_chat_server', type: 'module', nickname: 'chat'),
+      (name: 'random_pub_dep', type: 'none', nickname: null),
+    ]);
+    final modules = ModuleDiscoverer.discover(
+      Directory(p.join(tempRoot.path, 'app_server')),
+    );
+    expect(modules.length, 2);
+    expect(modules.map((m) => m.dartPkgName), [
+      'serverpod_auth_idp_server',
+      'serverpod_chat_server',
+    ]);
+    expect(modules.map((m) => m.nickname), ['auth', 'chat']);
+  });
+
+  test('returns modules sorted by dart-pkg name (deterministic output)', () {
+    scaffoldWorkspace(packages: [
+      (name: 'app_server', type: 'server', nickname: null),
+      (name: 'zebra_module', type: 'module', nickname: 'zeb'),
+      (name: 'apple_module', type: 'module', nickname: 'app'),
+      (name: 'mango_module', type: 'module', nickname: 'man'),
+    ]);
+    final modules = ModuleDiscoverer.discover(
+      Directory(p.join(tempRoot.path, 'app_server')),
+    );
+    expect(
+      modules.map((m) => m.dartPkgName),
+      ['apple_module', 'mango_module', 'zebra_module'],
+    );
+  });
+
+  test('walks up to find the workspace package_config from a nested dir', () {
+    scaffoldWorkspace(packages: [
+      (name: 'app_server', type: 'server', nickname: null),
+      (name: 'auth', type: 'module', nickname: 'auth'),
+    ]);
+    // Pretend the user invoked from a nested working directory.
+    final nested = Directory(p.join(tempRoot.path, 'app_server', 'lib', 'src'))
+      ..createSync(recursive: true);
+    final modules = ModuleDiscoverer.discover(nested);
+    expect(modules.length, 1);
+    expect(modules.single.nickname, 'auth');
+  });
+
+  test('throws StateError when package_config.json is missing', () {
+    final orphan = Directory(p.join(tempRoot.path, 'orphan'))
+      ..createSync(recursive: true);
+    expect(
+      () => ModuleDiscoverer.discover(orphan),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('skips modules whose generator.yaml lacks a nickname', () {
+    scaffoldWorkspace(packages: [
+      (name: 'app_server', type: 'server', nickname: null),
+      // Module with no nickname — invalid Serverpod module config.
+      (name: 'broken_module', type: 'module', nickname: null),
+      (name: 'good_module', type: 'module', nickname: 'good'),
+    ]);
+    final modules = ModuleDiscoverer.discover(
+      Directory(p.join(tempRoot.path, 'app_server')),
+    );
+    expect(modules.length, 1);
+    expect(modules.single.dartPkgName, 'good_module');
+  });
+}

--- a/test/module_discoverer_test.dart
+++ b/test/module_discoverer_test.dart
@@ -120,6 +120,20 @@ void main() {
     );
   });
 
+  test('skips the project itself when it is module-typed (no self-discovery)',
+      () {
+    scaffoldWorkspace(packages: [
+      // The "app" being generated IS itself a module.
+      (name: 'self_module', type: 'module', nickname: 'selfmod'),
+      (name: 'other_module', type: 'module', nickname: 'other'),
+    ]);
+    final modules = ModuleDiscoverer.discover(
+      Directory(p.join(tempRoot.path, 'self_module')),
+    );
+    expect(modules.length, 1);
+    expect(modules.single.dartPkgName, 'other_module');
+  });
+
   test('skips modules whose generator.yaml lacks a nickname', () {
     scaffoldWorkspace(packages: [
       (name: 'app_server', type: 'server', nickname: null),

--- a/test/module_import_lines_test.dart
+++ b/test/module_import_lines_test.dart
@@ -1,0 +1,165 @@
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_typescript_bridge/src/discovery/module_class_index.dart';
+import 'package:serverpod_typescript_bridge/src/discovery/module_client_layout.dart';
+import 'package:serverpod_typescript_bridge/src/emit/module_import_lines.dart';
+import 'package:test/test.dart';
+
+void main() {
+  ModuleClientLayout layoutFor(String dartPkg, String npmName) {
+    return ModuleClientLayout(
+      dartPkgName: dartPkg,
+      outputDir: Directory('/tmp/$npmName'),
+      npmPackageName: npmName,
+      relativeFromAppClient: '../$npmName',
+    );
+  }
+
+  TypeDefinition simple(String className, {bool nullable = false}) {
+    return TypeDefinition(className: className, nullable: nullable);
+  }
+
+  TypeDefinition listOf(TypeDefinition elem) {
+    return TypeDefinition(
+      className: 'List',
+      generics: [elem],
+      nullable: false,
+    );
+  }
+
+  TypeDefinition mapOf(TypeDefinition key, TypeDefinition value) {
+    return TypeDefinition(
+      className: 'Map',
+      generics: [key, value],
+      nullable: false,
+    );
+  }
+
+  test('returns no import lines when no module types appear', () {
+    final index = ModuleClassIndex.forTesting(classToLayout: const {});
+    final lines = ModuleImportLines(index).forTypes([
+      simple('String'),
+      simple('int'),
+      listOf(simple('SomeLocalType')),
+    ]);
+    expect(lines, isEmpty);
+  });
+
+  test('emits one import per module package, alphabetised', () {
+    final auth = layoutFor('auth_server', 'auth_typescript_client');
+    final chat = layoutFor('chat_server', 'chat_typescript_client');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {'AuthSuccess': auth, 'ChatMessage': chat},
+    );
+
+    final lines = ModuleImportLines(index).forTypes([
+      simple('AuthSuccess'),
+      simple('ChatMessage'),
+    ]);
+
+    expect(lines, [
+      "import { AuthSuccess } from 'auth_typescript_client';",
+      "import { ChatMessage } from 'chat_typescript_client';",
+    ]);
+  });
+
+  test('collapses multiple references to the same module into one line', () {
+    final auth = layoutFor('auth_server', 'auth_ts');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {
+        'AuthSuccess': auth,
+        'AuthFailure': auth,
+        'AuthChallenge': auth,
+      },
+    );
+
+    final lines = ModuleImportLines(index).forTypes([
+      simple('AuthSuccess'),
+      simple('AuthChallenge'),
+      simple('AuthFailure'),
+    ]);
+
+    expect(lines, [
+      "import { AuthChallenge, AuthFailure, AuthSuccess } from 'auth_ts';",
+    ]);
+  });
+
+  test('walks generics — List<ModuleType> brings in the inner module class',
+      () {
+    final auth = layoutFor('auth_server', 'auth_ts');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {'AuthUser': auth},
+    );
+
+    final lines = ModuleImportLines(index).forTypes([
+      listOf(simple('AuthUser')),
+      mapOf(simple('String'), listOf(simple('AuthUser'))),
+    ]);
+
+    expect(lines, ["import { AuthUser } from 'auth_ts';"]);
+  });
+
+  test('enums also bring in their Codec sibling', () {
+    final auth = layoutFor('auth_server', 'auth_ts');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {'Role': auth},
+      enumClassNames: {'Role'},
+    );
+
+    final lines = ModuleImportLines(index).forTypes([simple('Role')]);
+
+    expect(lines, ["import { Role, RoleCodec } from 'auth_ts';"]);
+  });
+
+  test('sealed bases also bring in their Base dispatcher sibling', () {
+    final auth = layoutFor('auth_server', 'auth_ts');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {'Animal': auth},
+      sealedClassNames: {'Animal'},
+    );
+
+    final lines = ModuleImportLines(index).forTypes([simple('Animal')]);
+
+    expect(lines, ["import { Animal, AnimalBase } from 'auth_ts';"]);
+  });
+
+  test('mix of plain, sealed, and enum module classes from one package', () {
+    final auth = layoutFor('auth_server', 'auth_ts');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {
+        'AuthSuccess': auth,
+        'Animal': auth,
+        'Role': auth,
+      },
+      sealedClassNames: {'Animal'},
+      enumClassNames: {'Role'},
+    );
+
+    final lines = ModuleImportLines(index).forTypes([
+      simple('AuthSuccess'),
+      simple('Animal'),
+      simple('Role'),
+    ]);
+
+    expect(lines, [
+      "import { Animal, AnimalBase, AuthSuccess, Role, RoleCodec } "
+          "from 'auth_ts';",
+    ]);
+  });
+
+  test('ignores non-module class names entirely', () {
+    final auth = layoutFor('auth_server', 'auth_ts');
+    final index = ModuleClassIndex.forTesting(
+      classToLayout: {'AuthUser': auth},
+    );
+
+    final lines = ModuleImportLines(index).forTypes([
+      simple('SomeLocalType'),
+      simple('AnotherUnknownType'),
+    ]);
+
+    expect(lines, isEmpty);
+  });
+}

--- a/test/module_import_lines_test.dart
+++ b/test/module_import_lines_test.dart
@@ -13,7 +13,6 @@ void main() {
       dartPkgName: dartPkg,
       outputDir: Directory('/tmp/$npmName'),
       npmPackageName: npmName,
-      relativeFromAppClient: '../$npmName',
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #35
Closes #36
Closes #37
Closes #38
Closes #39
Closes #41

v0.2.0 ships **module-aware generation**. The CLI now walks `.dart_tool/package_config.json` for the project's Serverpod module dependencies and recursively generates a TypeScript client per module as a sibling of the app client. The app client picks them up via `file:..` deps in `package.json` so a single `npm install` resolves the whole graph in place — no npm publishing required.

For module-defined types the project actually references (e.g. `AuthSuccess` from `serverpod_auth_idp_server`), generated model and endpoint files now emit `import { Name<, NameBase>?<, NameCodec>? } from '<module-pkg>';` lines instead of v0.1.4's `unknown /* TODO */` placeholder. The protocol switch in `protocol.ts` gains a case per referenced module class so wire envelopes like `auth.AuthSuccess` round-trip into a real typed value.

## What's in the box

- `ModuleDiscoverer` (#35) — reads `package_config.json`, filters to packages with `type: module` in `config/generator.yaml`.
- `ModuleClientLayout` / `ModuleLayoutResolver` (#36) — per-module output dir + npm name; configurable via `typescript_client_modules:` in generator.yaml.
- `ModuleClassIndex` — `className → layout` index built from each module's IR; flags sealed bases and enums.
- `GenerationPipeline` (#41) — the per-project flow shared by the app and every module dep.
- `ModuleImportLines` (#37) — groups referenced module classes by npm package and emits one import line per package, alphabetised.
- `ModelEmitter` / `EndpointEmitter` — emit cross-package import lines.
- `ScaffoldEmitter` (#38) — injects `dependencies` block in `package.json` with `file:..` entries per referenced module.
- `ClientEmitter` (#39) — protocol switch dispatches module classes through bare imported symbols.
- New CLI flag `--no-gen-modules` opts out (default: enabled).

## Test plan

- [x] `dart analyze` — clean.
- [x] `dart test` — 100/100 passing (8 new `ModuleImportLines` unit tests; 5 new `ClientEmitter` integration tests covering both the no-modules path and the module-references path).
- [x] No-modules emission is byte-equivalent to v0.1 (asserted in `client_emitter_modules_test.dart`).
- [ ] Smoke test against `freedive_finder_project` (real `serverpod_auth_idp_server` consumer) — to be run by maintainer post-merge before tagging v0.2.0.

## Files

- 5 new emit/discovery/analyzer modules (`ir_walker.dart`, `module_import_lines.dart`, `module_discoverer.dart`, `module_client_layout.dart`, `module_class_index.dart`).
- 1 new CLI module (`generation_pipeline.dart`).
- Refactor: `client_emitter.dart`, `model_emitter.dart`, `endpoint_emitter.dart`, `ts_type_mapper.dart`, `scaffold_emitter.dart`, `output_paths.dart`, `generate_command.dart`.
- 4 new test files.
- README + CHANGELOG updated; pubspec bumped to 0.2.0.

