### PR TITLE
v0.2.1: load module IR without requiring sibling Dart client pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.2.1
+
+- Bugfix: loading a Serverpod module's IR no longer requires the
+  module's sibling Dart client package to exist on disk. v0.2.0
+  routed module loading through `GeneratorConfig.load`, which
+  validates `client_package_path/pubspec.yaml` — but pub-cache
+  installs ship the server package alone, so generation crashed
+  with `Failed to load client pubspec.yaml`. The new
+  `ProtocolLoader.loadForModule(...)` synthesises a minimal
+  `GeneratorConfig` from the module's own `pubspec.yaml` +
+  `config/generator.yaml` and skips the cross-package validation
+  (we never emit a Dart client for the module anyway). The
+  generation pipeline now flips into this mode via the new
+  `isModulePackage: true` flag for the module-generation pass.
+
 ## 0.2.0
 
 - Module-aware generation. The CLI now walks `.dart_tool/package_config.json`

--- a/lib/src/analyzer/protocol_loader.dart
+++ b/lib/src/analyzer/protocol_loader.dart
@@ -14,19 +14,45 @@ import 'package:serverpod_cli/src/analyzer/dart/definitions.dart'
     show EndpointDefinition;
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:serverpod_shared/serverpod_shared.dart' show DatabaseDialect;
+import 'package:yaml/yaml.dart';
 
 /// Builds a [ProtocolDefinition] for a Serverpod server package by reusing
 /// `serverpod_cli`'s own analyzers — same IR, no parser drift.
 class ProtocolLoader {
-  /// Loads the IR for the given [serverDirectory].
+  /// Loads the IR for the given [serverDirectory] via `GeneratorConfig.load`.
+  /// Use this for the user's own server package, where the sibling Dart
+  /// client package lives at the path declared in `config/generator.yaml`.
   ///
   /// Throws [ProtocolLoaderException] if the analyzer reports severe
   /// errors (malformed YAML, invalid endpoint signature, etc.).
   static Future<ProtocolDefinition> load(Directory serverDirectory) async {
     _ensureExperimentalFeaturesInitialised();
     final config = await _loadConfig(serverDirectory);
+    return _runAnalyses(config);
+  }
+
+  /// Loads the IR for a Serverpod *module* whose source typically lives
+  /// under the user's pub-cache. `GeneratorConfig.load` would fail here:
+  /// it validates that the dart client sibling package's `pubspec.yaml`
+  /// exists at `client_package_path`, but pub-cache modules ship the
+  /// server package alone — the client is a separate hosted package.
+  ///
+  /// This builds a minimal [GeneratorConfig] from the module's own
+  /// `config/generator.yaml` + `pubspec.yaml` instead, populating only
+  /// the fields the IR analyzers actually consult.
+  static Future<ProtocolDefinition> loadForModule(
+    Directory serverDirectory,
+  ) async {
+    _ensureExperimentalFeaturesInitialised();
+    final config = _synthesizeModuleConfig(serverDirectory);
+    return _runAnalyses(config);
+  }
+
+  static Future<ProtocolDefinition> _runAnalyses(GeneratorConfig config) async {
     final models = await _runModelAnalysis(config);
     final endpoints = await _runEndpointAnalysis(config);
     return ProtocolDefinition(
@@ -34,6 +60,73 @@ class ProtocolLoader {
       models: models,
       futureCalls: const [],
     );
+  }
+
+  /// Public sibling of [loadForModule]: builds the same synthesised
+  /// [GeneratorConfig] for callers that need the config object directly
+  /// (e.g. the generation pipeline, which threads it into emitters).
+  static GeneratorConfig synthesizeModuleConfig(Directory serverDirectory) =>
+      _synthesizeModuleConfig(serverDirectory);
+
+  /// Reads the module's `pubspec.yaml` (for the package name) and
+  /// `config/generator.yaml` (for the client-path declaration) and
+  /// builds a [GeneratorConfig] without any cross-package validation.
+  ///
+  /// The dart client fields are placeholders — we never emit a dart
+  /// client for the module, so they're never read.
+  static GeneratorConfig _synthesizeModuleConfig(Directory serverDirectory) {
+    final dirParts = p.split(serverDirectory.path);
+    final pubspecName = _readPubspecName(serverDirectory);
+    final generatorYaml = _readGeneratorYaml(serverDirectory);
+    final clientPath = generatorYaml['client_package_path'] is String
+        ? generatorYaml['client_package_path'] as String
+        : '../${pubspecName}_client';
+
+    return GeneratorConfig(
+      name: pubspecName,
+      type: PackageType.module,
+      serverPackage: pubspecName,
+      dartClientPackage: '${pubspecName}_client',
+      dartClientDependsOnServiceClient: false,
+      serverPackageDirectoryPathParts: dirParts,
+      sharedModelsSourcePathsParts: const {},
+      relativeDartClientPackagePathParts: p.split(clientPath),
+      modules: const [],
+      extraClasses: const [],
+      enabledFeatures: ServerpodFeature.values
+          .where((f) => f.defaultValue)
+          .toList(),
+      databaseDialect: DatabaseDialect.postgres,
+    );
+  }
+
+  static String _readPubspecName(Directory serverDirectory) {
+    final pubspec = File(p.join(serverDirectory.path, 'pubspec.yaml'));
+    if (!pubspec.existsSync()) {
+      throw ProtocolLoaderException._(
+        ProtocolLoaderPhase.config,
+        'Module package at ${serverDirectory.path} has no pubspec.yaml. '
+        'Cannot determine module name.',
+      );
+    }
+    final yaml = loadYaml(pubspec.readAsStringSync());
+    if (yaml is! YamlMap || yaml['name'] is! String) {
+      throw ProtocolLoaderException._(
+        ProtocolLoaderPhase.config,
+        'Module pubspec.yaml at ${pubspec.path} is missing a top-level '
+        '`name:` field.',
+      );
+    }
+    return yaml['name'] as String;
+  }
+
+  static YamlMap _readGeneratorYaml(Directory serverDirectory) {
+    final file = File(
+      p.join(serverDirectory.path, 'config', 'generator.yaml'),
+    );
+    if (!file.existsSync()) return YamlMap();
+    final yaml = loadYaml(file.readAsStringSync());
+    return yaml is YamlMap ? yaml : YamlMap();
   }
 
   static bool _experimentalFeaturesInitialised = false;

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -128,6 +128,7 @@ class GenerateCommand extends Command<int> {
           serverDir: mod.serverPkgDir,
           outputDir: layout.outputDir,
           moduleIndex: moduleIndex,
+          isModulePackage: true,
         );
       } catch (e) {
         stderr.writeln(

--- a/lib/src/cli/generation_pipeline.dart
+++ b/lib/src/cli/generation_pipeline.dart
@@ -28,9 +28,18 @@ class GenerationPipeline {
     required Directory serverDir,
     required Directory outputDir,
     required ModuleClassIndex moduleIndex,
+    bool isModulePackage = false,
   }) async {
-    final config = await _loadConfig(serverDir);
-    final ir = await ProtocolLoader.load(serverDir);
+    // Module packages typically live under pub-cache and don't ship a
+    // sibling dart client, so `GeneratorConfig.load` would fail on the
+    // client-pubspec validation. The synthetic-config path mirrors the
+    // module-IR loading we already do in [ModuleClassIndex.build].
+    final config = isModulePackage
+        ? ProtocolLoader.synthesizeModuleConfig(serverDir)
+        : await _loadConfig(serverDir);
+    final ir = isModulePackage
+        ? await ProtocolLoader.loadForModule(serverDir)
+        : await ProtocolLoader.load(serverDir);
 
     final paths = OutputPaths(
       outputDir: outputDir,

--- a/lib/src/discovery/module_class_index.dart
+++ b/lib/src/discovery/module_class_index.dart
@@ -61,7 +61,10 @@ class ModuleClassIndex {
 
     for (final mod in discovered) {
       final layout = layoutResolver.resolve(mod.dartPkgName);
-      final ir = await ProtocolLoader.load(mod.serverPkgDir);
+      // Modules typically live under the user's pub-cache, where the
+      // sibling dart client package isn't present — `loadForModule`
+      // synthesises a config that bypasses that validation.
+      final ir = await ProtocolLoader.loadForModule(mod.serverPkgDir);
       for (final m in ir.models) {
         classToLayout[m.className] = layout;
         if (m is ModelClassDefinition && m.isSealed) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 
@@ -24,6 +24,9 @@ dependencies:
   # emitting TypeScript. Pinned to a minor range — coupling to internal
   # `src/` is documented in lib/src/analyzer/protocol_loader.dart.
   serverpod_cli: ^3.4.7
+  # We construct a synthetic GeneratorConfig for module-from-pub-cache
+  # loading; that requires DatabaseDialect from serverpod_shared.
+  serverpod_shared: ^3.4.7
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
## Summary

v0.2.1 hotfix.

v0.2.0 generation crashed against any real-world consumer that depends on Serverpod modules from pub.dev (e.g. `serverpod_auth_core_server`). Reported error:

```
ProtocolLoaderException[config]: Failed to load GeneratorConfig from
  /Users/.../serverpod_auth_core_server-3.4.7:
  Failed to load client pubspec.yaml. If you are using a none default path
  it has to be specified in the config/generator.yaml file!
```

Root cause: pub-cache installs ship the server package alone; the matching `<module>_client` Dart package is a separate hosted entry. v0.2.0 routed module loading through `GeneratorConfig.load`, which validates the dart client pubspec at the relative path declared in `config/generator.yaml` — that sibling doesn't exist for pub-cache module installs.

Fix: introduce `ProtocolLoader.loadForModule(serverDir)` and a public `synthesizeModuleConfig(serverDir)` that build a minimal `GeneratorConfig` from the module's own `pubspec.yaml` + `config/generator.yaml`, skipping the cross-package validation. We never emit a Dart client for module packages, so the synthesised dart-client fields are placeholders.

Wires the new path through `ModuleClassIndex.build` and `GenerationPipeline.run(isModulePackage: true)`; `generate_command` sets the flag for every discovered module.

## Test plan

- [x] `dart analyze` clean.
- [x] `dart test` 101/101 passing.
- [ ] Smoke test against `freedive_finder_project` with `serverpod_auth_core_server` / `serverpod_auth_idp_server` / `serverpod_cloud_storage_s3` (maintainer to verify; this is the original bug report).
