### PR TITLE
v0.2.2: populate cross-module deps in synthesised module configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.2.2
+
+- Bugfix: synthesised module configs now populate their `modules:`
+  list from the module's own `config/generator.yaml`. v0.2.1 left it
+  empty, so any module whose source references another module by
+  nickname (e.g. `serverpod_auth_idp_server` references
+  `module:auth:AuthUser` from `serverpod_auth_core_server`) failed
+  with `The referenced module "auth" is not found`. The full set of
+  discovered modules now flows through `ModuleClassIndex.build` and
+  `GenerationPipeline.run` as a `List<ModuleDependency>`, and the
+  synthesiser uses it to construct real `ModuleConfig` entries with
+  the right `serverPackageDirectoryPathParts`.
+
 ## 0.2.1
 
 - Bugfix: loading a Serverpod module's IR no longer requires the

--- a/lib/src/analyzer/protocol_loader.dart
+++ b/lib/src/analyzer/protocol_loader.dart
@@ -64,6 +64,19 @@ class ProtocolLoader {
     return _runAnalyses(config);
   }
 
+  /// Runs the same model + endpoint analyses as [load] / [loadForModule]
+  /// but against an already-built [config]. Useful when the caller has
+  /// synthesised a config out-of-band (e.g. [GenerationPipeline.run] in
+  /// module mode) and wants to reuse it for both emission AND IR loading
+  /// — a single read of `pubspec.yaml` + `config/generator.yaml`, no
+  /// risk of the two halves seeing different on-disk state.
+  static Future<ProtocolDefinition> loadFromConfig(
+    GeneratorConfig config,
+  ) async {
+    _ensureExperimentalFeaturesInitialised();
+    return _runAnalyses(config);
+  }
+
   static Future<ProtocolDefinition> _runAnalyses(GeneratorConfig config) async {
     final models = await _runModelAnalysis(config);
     final endpoints = await _runEndpointAnalysis(config);
@@ -174,7 +187,10 @@ class ProtocolLoader {
         'Cannot determine module name.',
       );
     }
-    final yaml = loadYaml(pubspec.readAsStringSync());
+    final yaml = _safeLoadYaml(
+      pubspec,
+      context: 'module pubspec.yaml',
+    );
     if (yaml is! YamlMap || yaml['name'] is! String) {
       throw ProtocolLoaderException._(
         ProtocolLoaderPhase.config,
@@ -190,8 +206,47 @@ class ProtocolLoader {
       p.join(serverDirectory.path, 'config', 'generator.yaml'),
     );
     if (!file.existsSync()) return YamlMap();
-    final yaml = loadYaml(file.readAsStringSync());
+    final yaml = _safeLoadYaml(
+      file,
+      context: 'module config/generator.yaml',
+    );
     return yaml is YamlMap ? yaml : YamlMap();
+  }
+
+  /// Reads + parses a YAML file, translating any `YamlException` /
+  /// `FileSystemException` / `FormatException` into a typed
+  /// [ProtocolLoaderException] with [ProtocolLoaderPhase.config] so the
+  /// CLI surfaces a consistent error class instead of leaking raw
+  /// parser exceptions. Stack trace preserved via
+  /// [Error.throwWithStackTrace].
+  static dynamic _safeLoadYaml(File file, {required String context}) {
+    try {
+      return loadYaml(file.readAsStringSync());
+    } on YamlException catch (e, st) {
+      Error.throwWithStackTrace(
+        ProtocolLoaderException._(
+          ProtocolLoaderPhase.config,
+          'Failed to parse $context at ${file.path}: ${e.message}',
+        ),
+        st,
+      );
+    } on FileSystemException catch (e, st) {
+      Error.throwWithStackTrace(
+        ProtocolLoaderException._(
+          ProtocolLoaderPhase.config,
+          'Failed to read $context at ${file.path}: ${e.message}',
+        ),
+        st,
+      );
+    } on FormatException catch (e, st) {
+      Error.throwWithStackTrace(
+        ProtocolLoaderException._(
+          ProtocolLoaderPhase.config,
+          'Failed to parse $context at ${file.path}: ${e.message}',
+        ),
+        st,
+      );
+    }
   }
 
   static bool _experimentalFeaturesInitialised = false;

--- a/lib/src/analyzer/protocol_loader.dart
+++ b/lib/src/analyzer/protocol_loader.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart'
     show EndpointDefinition;
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/config/config.dart' show ModuleConfig;
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
@@ -44,11 +45,22 @@ class ProtocolLoader {
   /// This builds a minimal [GeneratorConfig] from the module's own
   /// `config/generator.yaml` + `pubspec.yaml` instead, populating only
   /// the fields the IR analyzers actually consult.
+  ///
+  /// [knownModules] is the full list of modules the parent project
+  /// discovered. It's used to resolve cross-module references inside
+  /// the loaded module — e.g. `serverpod_auth_idp_server` declares
+  /// `module:auth:AuthUser` references and the `auth` nickname must
+  /// resolve to `serverpod_auth_core_server`'s server-pkg dir or the
+  /// analyzer fails with `The referenced module "auth" is not found`.
   static Future<ProtocolDefinition> loadForModule(
-    Directory serverDirectory,
-  ) async {
+    Directory serverDirectory, {
+    List<ModuleDependency> knownModules = const [],
+  }) async {
     _ensureExperimentalFeaturesInitialised();
-    final config = _synthesizeModuleConfig(serverDirectory);
+    final config = _synthesizeModuleConfig(
+      serverDirectory,
+      knownModules: knownModules,
+    );
     return _runAnalyses(config);
   }
 
@@ -65,16 +77,24 @@ class ProtocolLoader {
   /// Public sibling of [loadForModule]: builds the same synthesised
   /// [GeneratorConfig] for callers that need the config object directly
   /// (e.g. the generation pipeline, which threads it into emitters).
-  static GeneratorConfig synthesizeModuleConfig(Directory serverDirectory) =>
-      _synthesizeModuleConfig(serverDirectory);
+  static GeneratorConfig synthesizeModuleConfig(
+    Directory serverDirectory, {
+    List<ModuleDependency> knownModules = const [],
+  }) =>
+      _synthesizeModuleConfig(serverDirectory, knownModules: knownModules);
 
   /// Reads the module's `pubspec.yaml` (for the package name) and
   /// `config/generator.yaml` (for the client-path declaration) and
   /// builds a [GeneratorConfig] without any cross-package validation.
   ///
   /// The dart client fields are placeholders — we never emit a dart
-  /// client for the module, so they're never read.
-  static GeneratorConfig _synthesizeModuleConfig(Directory serverDirectory) {
+  /// client for the module, so they're never read. The `modules:`
+  /// list is populated from the module's own `modules:` block in
+  /// `generator.yaml`, cross-referenced against [knownModules].
+  static GeneratorConfig _synthesizeModuleConfig(
+    Directory serverDirectory, {
+    required List<ModuleDependency> knownModules,
+  }) {
     final dirParts = p.split(serverDirectory.path);
     final pubspecName = _readPubspecName(serverDirectory);
     final generatorYaml = _readGeneratorYaml(serverDirectory);
@@ -91,7 +111,7 @@ class ProtocolLoader {
       serverPackageDirectoryPathParts: dirParts,
       sharedModelsSourcePathsParts: const {},
       relativeDartClientPackagePathParts: p.split(clientPath),
-      modules: const [],
+      modules: _moduleDependenciesFor(generatorYaml, knownModules),
       extraClasses: const [],
       enabledFeatures: ServerpodFeature.values
           .where((f) => f.defaultValue)
@@ -99,6 +119,51 @@ class ProtocolLoader {
       databaseDialect: DatabaseDialect.postgres,
     );
   }
+
+  /// Builds [ModuleConfig] entries for every module this module
+  /// declares as a dep in its own `generator.yaml`. The [knownModules]
+  /// list (every Serverpod module the PARENT project discovered)
+  /// supplies the on-disk path each entry needs.
+  ///
+  /// Modules referenced in generator.yaml but NOT in [knownModules]
+  /// are skipped silently — the analyzer will surface the missing
+  /// reference if the module's source actually depends on them.
+  static List<ModuleConfig> _moduleDependenciesFor(
+    YamlMap generatorYaml,
+    List<ModuleDependency> knownModules,
+  ) {
+    final modulesNode = generatorYaml['modules'];
+    if (modulesNode is! YamlMap) return const [];
+
+    // Index discovered modules by their `<name-without-_server>`,
+    // matching how generator.yaml's `modules:` block names them.
+    final knownByBase = <String, ModuleDependency>{
+      for (final m in knownModules) _stripServerSuffix(m.dartPkgName): m,
+    };
+
+    final out = <ModuleConfig>[];
+    for (final entry in modulesNode.entries) {
+      final base = entry.key;
+      final spec = entry.value;
+      if (base is! String) continue;
+      final known = knownByBase[base];
+      if (known == null) continue;
+      final nickname = (spec is YamlMap && spec['nickname'] is String)
+          ? spec['nickname'] as String
+          : known.nickname;
+      out.add(ModuleConfig(
+        type: PackageType.module,
+        name: base,
+        nickname: nickname,
+        migrationVersions: const [],
+        serverPackageDirectoryPathParts: p.split(known.serverPkgPath),
+      ));
+    }
+    return out;
+  }
+
+  static String _stripServerSuffix(String pkg) =>
+      pkg.endsWith('_server') ? pkg.substring(0, pkg.length - '_server'.length) : pkg;
 
   static String _readPubspecName(Directory serverDirectory) {
     final pubspec = File(p.join(serverDirectory.path, 'pubspec.yaml'));
@@ -214,4 +279,31 @@ class ProtocolLoaderException implements Exception {
   @override
   String toString() =>
       'ProtocolLoaderException[${phase.name}]: $message';
+}
+
+/// Minimal description of a discovered Serverpod module — passed into
+/// [ProtocolLoader.loadForModule] / [ProtocolLoader.synthesizeModuleConfig]
+/// so the synthesised [GeneratorConfig] can resolve cross-module
+/// references (e.g. `module:auth:AuthUser`).
+///
+/// Decoupled from the richer `DiscoveredModule` class in
+/// `discovery/module_discoverer.dart` to keep `protocol_loader.dart`
+/// from depending on the discovery layer (which depends on this file
+/// transitively for IR loading).
+class ModuleDependency {
+  const ModuleDependency({
+    required this.dartPkgName,
+    required this.nickname,
+    required this.serverPkgPath,
+  });
+
+  /// Dart package name as seen in `package_config.json`
+  /// (e.g. `serverpod_auth_core_server`).
+  final String dartPkgName;
+
+  /// The wire / generator.yaml nickname (e.g. `auth`).
+  final String nickname;
+
+  /// Absolute on-disk path to the module's server package directory.
+  final String serverPkgPath;
 }

--- a/lib/src/cli/generate_command.dart
+++ b/lib/src/cli/generate_command.dart
@@ -115,6 +115,15 @@ class GenerateCommand extends Command<int> {
       layoutResolver: layoutResolver,
     );
 
+    final knownModules = [
+      for (final m in discovered)
+        ModuleDependency(
+          dartPkgName: m.dartPkgName,
+          nickname: m.nickname,
+          serverPkgPath: m.serverPkgDir.path,
+        ),
+    ];
+
     // 2. Generate each discovered module FIRST so the app client can
     //    declare `file:..` deps that resolve cleanly.
     for (final mod in discovered) {
@@ -129,6 +138,7 @@ class GenerateCommand extends Command<int> {
           outputDir: layout.outputDir,
           moduleIndex: moduleIndex,
           isModulePackage: true,
+          knownModules: knownModules,
         );
       } catch (e) {
         stderr.writeln(

--- a/lib/src/cli/generation_pipeline.dart
+++ b/lib/src/cli/generation_pipeline.dart
@@ -33,18 +33,18 @@ class GenerationPipeline {
   }) async {
     // Module packages typically live under pub-cache and don't ship a
     // sibling dart client, so `GeneratorConfig.load` would fail on the
-    // client-pubspec validation. The synthetic-config path mirrors the
-    // module-IR loading we already do in [ModuleClassIndex.build].
+    // client-pubspec validation. We synthesise a config from the
+    // module's own pubspec + generator.yaml ONCE here and reuse it for
+    // both emission (below) and IR loading — a second pass would
+    // re-read the same files and could legitimately see different
+    // on-disk state if the user is generating mid-edit.
     // [knownModules] lets the synthesised config resolve cross-module
     // references inside the module being generated.
     final config = isModulePackage
         ? ProtocolLoader.synthesizeModuleConfig(serverDir,
             knownModules: knownModules)
         : await _loadConfig(serverDir);
-    final ir = isModulePackage
-        ? await ProtocolLoader.loadForModule(serverDir,
-            knownModules: knownModules)
-        : await ProtocolLoader.load(serverDir);
+    final ir = await ProtocolLoader.loadFromConfig(config);
 
     final paths = OutputPaths(
       outputDir: outputDir,

--- a/lib/src/cli/generation_pipeline.dart
+++ b/lib/src/cli/generation_pipeline.dart
@@ -29,16 +29,21 @@ class GenerationPipeline {
     required Directory outputDir,
     required ModuleClassIndex moduleIndex,
     bool isModulePackage = false,
+    List<ModuleDependency> knownModules = const [],
   }) async {
     // Module packages typically live under pub-cache and don't ship a
     // sibling dart client, so `GeneratorConfig.load` would fail on the
     // client-pubspec validation. The synthetic-config path mirrors the
     // module-IR loading we already do in [ModuleClassIndex.build].
+    // [knownModules] lets the synthesised config resolve cross-module
+    // references inside the module being generated.
     final config = isModulePackage
-        ? ProtocolLoader.synthesizeModuleConfig(serverDir)
+        ? ProtocolLoader.synthesizeModuleConfig(serverDir,
+            knownModules: knownModules)
         : await _loadConfig(serverDir);
     final ir = isModulePackage
-        ? await ProtocolLoader.loadForModule(serverDir)
+        ? await ProtocolLoader.loadForModule(serverDir,
+            knownModules: knownModules)
         : await ProtocolLoader.load(serverDir);
 
     final paths = OutputPaths(

--- a/lib/src/discovery/module_class_index.dart
+++ b/lib/src/discovery/module_class_index.dart
@@ -59,12 +59,27 @@ class ModuleClassIndex {
     final sealedClassNames = <String>{};
     final enumClassNames = <String>{};
 
+    final knownModules = [
+      for (final m in discovered)
+        ModuleDependency(
+          dartPkgName: m.dartPkgName,
+          nickname: m.nickname,
+          serverPkgPath: m.serverPkgDir.path,
+        ),
+    ];
+
     for (final mod in discovered) {
       final layout = layoutResolver.resolve(mod.dartPkgName);
       // Modules typically live under the user's pub-cache, where the
       // sibling dart client package isn't present — `loadForModule`
-      // synthesises a config that bypasses that validation.
-      final ir = await ProtocolLoader.loadForModule(mod.serverPkgDir);
+      // synthesises a config that bypasses that validation. We pass
+      // the full discovered set so the synthesised config can resolve
+      // cross-module references (e.g. auth_idp's `module:auth:...`
+      // pointing at auth_core).
+      final ir = await ProtocolLoader.loadForModule(
+        mod.serverPkgDir,
+        knownModules: knownModules,
+      );
       for (final m in ir.models) {
         classToLayout[m.className] = layout;
         if (m is ModelClassDefinition && m.isSealed) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 


### PR DESCRIPTION
## Summary

v0.2.2 hotfix.

v0.2.1 unblocked module-IR loading from pub-cache, but loading `serverpod_auth_idp_server` then crashed with:

```
ProtocolLoaderException[models]: Model analysis surfaced 18 error(s):
  - The referenced module "auth" is not found.
```

Root cause: `serverpod_auth_idp_server`'s YAML model files reference `module:auth:AuthUser` (where `auth` is the nickname for `serverpod_auth_core_server`). The synthesised `GeneratorConfig` v0.2.1 produced for auth_idp had `modules: const []`, so the analyzer had no entry for `auth` and rejected every cross-module relation.

Fix: thread the full discovered-module list through as a `List<ModuleDependency>`. The synthesiser now reads the module's own `config/generator.yaml` `modules:` block and constructs real `ModuleConfig` entries by looking each declared dep up in the discovered list (matched by `<base-name>` ↔ `<base-name>_server`).

## Wiring changes

- New `ModuleDependency` value type alongside `ProtocolLoader` (decoupled from `discovery/module_discoverer.dart`'s richer `DiscoveredModule` to avoid a circular import).
- `ProtocolLoader.loadForModule` and `ProtocolLoader.synthesizeModuleConfig` both gain a `knownModules: List<ModuleDependency>` param.
- `ModuleClassIndex.build` derives that list from `discovered` and forwards it.
- `GenerationPipeline.run` gains the same param and forwards it on the module pass.
- `generate_command` builds the list from `discovered` and passes it through.

## Test plan

- [x] `dart analyze` clean.
- [x] `dart test` 101/101 passing.
- [ ] Smoke against `freedive_finder_project` with the full auth_idp + auth_core stack (maintainer to verify; this is the original report).
