### PR TITLE
v0.2.3: scope ModuleClassIndex per-run + emit `export {}` on empty barrels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 0.2.3
+
+- Bugfix: when generating a module client (`serverpod_auth_core`,
+  `serverpod_auth_idp`, etc.), the per-run `ModuleClassIndex` is now
+  scoped to exclude the project's own classes. Previously the index
+  contained every discovered module — including the one currently being
+  emitted — so `ModuleImportLines` produced both a legitimate local
+  cross-file import (`import { AuthUser } from './auth_user.js'`) AND
+  a self-referential cross-package import
+  (`import { AuthUser } from 'serverpod_auth_core_typescript_client'`).
+  `tsc` then exploded with `Duplicate identifier 'AuthUser'` and
+  `Cannot find module 'serverpod_auth_core_typescript_client'` (a
+  package can't import from itself). `GenerationPipeline.run` now
+  computes `localNames` from the IR and passes
+  `moduleIndex.excluding(localNames)` everywhere it would have used
+  the raw index — emitter mappers, scaffold deps, protocol switch.
+- Bugfix: empty `endpoints/index.ts` and `protocol/index.ts` barrels
+  now emit `export {};` so TS treats them as modules. Modules without
+  any concrete endpoints (e.g. `serverpod_auth_core` exposes only
+  models and exceptions) previously broke the consuming package's
+  `tsc` with `File '…/endpoints/index.ts' is not a module`.
+
 ## 0.2.2
 
 - Bugfix: synthesised module configs now populate their `modules:`

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -24,3 +24,4 @@ paths:
   - test/module_client_layout_test.dart
   - test/module_import_lines_test.dart
   - test/client_emitter_modules_test.dart
+  - test/empty_barrel_emission_test.dart

--- a/lib/src/cli/generation_pipeline.dart
+++ b/lib/src/cli/generation_pipeline.dart
@@ -57,24 +57,29 @@ class GenerationPipeline {
       Directory(p.join(outputDir.path, 'src', 'endpoints')),
     ]);
 
-    final mapperConfig = _MapperConfig.fromIr(ir, moduleIndex);
+    // Scope the module index for THIS run by stripping out the project's
+    // own classes. `ModuleClassIndex.build` walks every discovered
+    // module — including the one we're about to emit — so without
+    // this filter `ModuleImportLines` would treat the project's own
+    // classes as foreign module classes and emit a self-referential
+    // cross-package import on top of the legitimate local cross-file
+    // import (and the protocol switch would emit a duplicate case
+    // dispatching to the project's own npm name).
+    final localNames = {for (final m in ir.models) m.className};
+    final scopedIndex = moduleIndex.excluding(localNames);
+    final mapperConfig = _MapperConfig.fromIr(ir, scopedIndex);
 
-    // Local types always shadow the module index — see
-    // `TsTypeMapper._mapModelOrEnum`. Filter them out before we ask
-    // the index for `file:..` deps or protocol-switch entries; they
-    // belong to THIS package, not to a sibling module.
-    final localNames = mapperConfig.projectClassNames;
     final referencedClassNames = IrWalker.allReferencedClassNames(ir);
     final referencedExternalNames = referencedClassNames.difference(localNames);
 
-    final moduleDeps = moduleIndex.referencedPackages(
+    final moduleDeps = scopedIndex.referencedPackages(
       referencedClassNames: referencedExternalNames,
       consumerDir: outputDir,
     );
 
     final referencedModuleClassNames = <String>{
       for (final name in referencedExternalNames)
-        if (moduleIndex.layoutFor(name) != null) name,
+        if (scopedIndex.layoutFor(name) != null) name,
     };
 
     final scaffold = ScaffoldEmitter(
@@ -104,7 +109,7 @@ class GenerationPipeline {
       outputDir: outputDir,
       tracker: tracker,
       config: config,
-      moduleIndex: moduleIndex,
+      moduleIndex: scopedIndex,
       referencedModuleClassNames: referencedModuleClassNames,
     ).emit(endpoints: ir.endpoints, models: ir.models);
 

--- a/lib/src/discovery/module_class_index.dart
+++ b/lib/src/discovery/module_class_index.dart
@@ -94,6 +94,34 @@ class ModuleClassIndex {
         enumClassNames);
   }
 
+  /// Returns a copy of this index with every name in [classNames]
+  /// removed. Used by [GenerationPipeline] to scope the index for the
+  /// project currently being generated — the project's own classes
+  /// belong in its local protocol barrel, NOT as cross-package imports
+  /// pointing back at itself.
+  ///
+  /// The `ModuleClassIndex.build` pass walks every discovered module
+  /// (including the one we're emitting), so without this filter the
+  /// per-emit `ModuleImportLines` would treat the project's own
+  /// classes as foreign module classes and produce both a local
+  /// cross-file import AND a self-referential cross-package import.
+  ModuleClassIndex excluding(Set<String> classNames) {
+    if (classNames.isEmpty) return this;
+    final filteredLayout = <String, ModuleClientLayout>{
+      for (final entry in _classToLayout.entries)
+        if (!classNames.contains(entry.key)) entry.key: entry.value,
+    };
+    final filteredSealed = <String>{
+      for (final n in _sealedClassNames)
+        if (!classNames.contains(n)) n,
+    };
+    final filteredEnum = <String>{
+      for (final n in _enumClassNames)
+        if (!classNames.contains(n)) n,
+    };
+    return ModuleClassIndex._(filteredLayout, filteredSealed, filteredEnum);
+  }
+
   bool get isEmpty => _classToLayout.isEmpty;
 
   /// Returns the layout for [className] if it's defined in any module,

--- a/lib/src/emit/endpoint_emitter.dart
+++ b/lib/src/emit/endpoint_emitter.dart
@@ -52,6 +52,11 @@ class EndpointEmitter {
       final stem = f.replaceAll(RegExp(r'\.ts$'), '');
       w.writeln("export * from './$stem.js';");
     }
+    // A barrel with zero exports is a script in TS's eyes and the
+    // `import * as r from './endpoints/index.js'` consumer fails with
+    // `File '…' is not a module`. The empty `export {}` is the
+    // canonical opt-in to module status.
+    if (filenames.isEmpty) w.writeln('export {};');
     _writeFile('index.ts', w.toString());
   }
 

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -131,6 +131,10 @@ class ModelEmitter {
       final stem = f.replaceAll(RegExp(r'\.ts$'), '');
       w.writeln("export * from './$stem.js';");
     }
+    // Empty barrels need an `export {};` so TS treats the file as a
+    // module — otherwise `import * as p from '../protocol/index.js'`
+    // fails with `is not a module`.
+    if (filenames.isEmpty) w.writeln('export {};');
     _writeFile('index.ts', w.toString());
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 

--- a/test/empty_barrel_emission_test.dart
+++ b/test/empty_barrel_emission_test.dart
@@ -1,0 +1,76 @@
+// Regression coverage for the v0.2.3 empty-barrel fix: when a project
+// (typically a Serverpod *module* like `serverpod_auth_core` that
+// exposes only models / exceptions, no concrete endpoints) emits an
+// empty `endpoints/index.ts` or `protocol/index.ts`, the file must
+// still be a TS module — otherwise the consuming top-level barrel's
+// `export * from './endpoints/index.js'` fails with `is not a module`.
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_typescript_bridge/src/discovery/module_class_index.dart';
+import 'package:serverpod_typescript_bridge/src/emit/endpoint_emitter.dart';
+import 'package:serverpod_typescript_bridge/src/emit/generated_file_tracker.dart';
+import 'package:serverpod_typescript_bridge/src/emit/model_emitter.dart';
+import 'package:serverpod_typescript_bridge/src/emit/ts_type_mapper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory outputDir;
+
+  setUp(() {
+    outputDir = Directory.systemTemp.createTempSync('sptb_empty_barrel_');
+  });
+
+  tearDown(() {
+    if (outputDir.existsSync()) outputDir.deleteSync(recursive: true);
+  });
+
+  GeneratedFileTracker freshTracker() {
+    return GeneratedFileTracker([
+      Directory(p.join(outputDir.path, 'src', 'protocol')),
+      Directory(p.join(outputDir.path, 'src', 'endpoints')),
+    ]);
+  }
+
+  TsTypeMapper bareMapper() {
+    return TsTypeMapper(moduleIndex: ModuleClassIndex.empty);
+  }
+
+  test('EndpointEmitter writes `export {};` when there are zero endpoints',
+      () {
+    EndpointEmitter(
+      outputDir: outputDir,
+      tracker: freshTracker(),
+      mapper: bareMapper(),
+    ).emitAll(const []);
+
+    final barrel =
+        File(p.join(outputDir.path, 'src', 'endpoints', 'index.ts'));
+    expect(barrel.existsSync(), isTrue,
+        reason: 'endpoint barrel must exist even when no endpoints emit');
+    final src = barrel.readAsStringSync();
+    expect(src, contains('export {};'),
+        reason:
+            'TS treats a file with no top-level imports/exports as a script;'
+            ' an explicit `export {};` is the canonical opt-in to module status');
+    expect(src, isNot(contains("export * from")),
+        reason: 'no per-endpoint re-exports should appear when none emitted');
+  });
+
+  test('ModelEmitter writes `export {};` when there are zero models', () {
+    ModelEmitter(
+      outputDir: outputDir,
+      tracker: freshTracker(),
+      mapper: bareMapper(),
+    ).emitAll(const []);
+
+    final barrel =
+        File(p.join(outputDir.path, 'src', 'protocol', 'index.ts'));
+    expect(barrel.existsSync(), isTrue,
+        reason: 'protocol barrel must exist even when no models emit');
+    final src = barrel.readAsStringSync();
+    expect(src, contains('export {};'));
+    expect(src, isNot(contains("export * from")),
+        reason: 'no per-model re-exports should appear when none emitted');
+  });
+}

--- a/test/module_import_lines_test.dart
+++ b/test/module_import_lines_test.dart
@@ -161,4 +161,66 @@ void main() {
 
     expect(lines, isEmpty);
   });
+
+  group('ModuleClassIndex.excluding (per-run scoping)', () {
+    test('strips named classes from layoutFor / sealed / enum lookups', () {
+      final auth = layoutFor('auth_server', 'auth_ts');
+      final index = ModuleClassIndex.forTesting(
+        classToLayout: {'AuthUser': auth, 'AuthRole': auth, 'Animal': auth},
+        sealedClassNames: {'Animal'},
+        enumClassNames: {'AuthRole'},
+      );
+
+      final scoped = index.excluding({'AuthUser', 'Animal'});
+      expect(scoped.layoutFor('AuthUser'), isNull);
+      expect(scoped.layoutFor('Animal'), isNull);
+      expect(scoped.layoutFor('AuthRole'), isNotNull);
+      expect(scoped.isSealed('Animal'), isFalse);
+      expect(scoped.isEnum('AuthRole'), isTrue);
+    });
+
+    test('returns the same instance when the exclusion set is empty', () {
+      final auth = layoutFor('auth_server', 'auth_ts');
+      final index = ModuleClassIndex.forTesting(
+        classToLayout: {'AuthUser': auth},
+      );
+      expect(identical(index.excluding(const {}), index), isTrue,
+          reason: 'no-op exclude should avoid an unnecessary copy');
+    });
+
+    test(
+        'ModuleImportLines on a scoped index never emits a self-referential '
+        'cross-package import for the project being generated', () {
+      // Scenario: generating `auth_core` itself. The full index contains
+      // its own classes (AuthUser, UserProfile) PLUS a separate module
+      // (chat) it depends on. Per-run scoping must strip the local names
+      // so the model files don't import from their own npm package.
+      final authCore = layoutFor('auth_core_server', 'auth_core_ts');
+      final chat = layoutFor('chat_server', 'chat_ts');
+      final fullIndex = ModuleClassIndex.forTesting(
+        classToLayout: {
+          'AuthUser': authCore,
+          'UserProfile': authCore,
+          'ChatMessage': chat,
+        },
+      );
+
+      final scoped = fullIndex.excluding({'AuthUser', 'UserProfile'});
+      final lines = ModuleImportLines(scoped).forTypes([
+        simple('AuthUser'), // local — must NOT appear in any import
+        simple('UserProfile'), // local — must NOT appear
+        simple('ChatMessage'), // foreign — should appear once
+      ]);
+
+      expect(lines, ["import { ChatMessage } from 'chat_ts';"],
+          reason:
+              'local classes must not produce cross-package imports back '
+              'to the package being generated');
+      expect(
+        lines.any((l) => l.contains('auth_core_ts')),
+        isFalse,
+        reason: 'no self-referential auth_core_ts import should appear',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

v0.2.3 hotfix.

v0.2.2 unblocked module IR loading + cross-module dep resolution, so generation now succeeds end-to-end on `freedive_finder_project` with auth_core + auth_idp deps. But the per-module `tsc` builds fail with two distinct errors:

```
serverpod_auth_core build:
  src/protocol/user_profile.ts: Duplicate identifier 'AuthUser'.
  src/protocol/user_profile.ts: Cannot find module 'serverpod_auth_core_typescript_client'.
  src/index.ts: File '.../endpoints/index.ts' is not a module.

serverpod_auth_idp build:
  same `Duplicate identifier` pattern for every enum it owns.
```

## Root causes

**1. Self-imports in module clients.** `ModuleClassIndex.build` walks every discovered module — including the one currently being emitted. When generating `serverpod_auth_core_typescript_client`, the module index still listed `AuthUser` as a foreign module class, so `ModuleImportLines.forTypes` produced a cross-package import (`from 'serverpod_auth_core_typescript_client'`) on top of the legitimate local cross-file import (`from './auth_user.js'`). A package can't import from itself, and the duplicate symbol breaks `tsc`.

**Fix:** `ModuleClassIndex.excluding(Set<String> classNames)` returns a copy with those names stripped. `GenerationPipeline.run` computes `localNames` from the loaded IR and passes `moduleIndex.excluding(localNames)` to the mapper, the scaffold deps lookup, the protocol-switch class-name set, and the ClientEmitter. The underlying index stays immutable; the per-run scoping happens in the pipeline.

**2. Empty `endpoints/index.ts` is treated as a script, not a module.** Modules without concrete endpoints (e.g. `serverpod_auth_core` only exposes models/exceptions) emit a barrel containing just the generated header. TypeScript treats a file with no top-level imports/exports as a script, so the consuming package barrel's `export * from './endpoints/index.js'` blows up with `File '…' is not a module`.

**Fix:** `EndpointEmitter._emitBarrel` and `ModelEmitter._emitProtocolBarrel` now write `export {};` when the filename list is empty — the canonical opt-in to module status.

## Test plan

- [x] `dart analyze` clean.
- [x] `dart test` 101/101 passing.
- [ ] Smoke against `freedive_finder_project` (maintainer to verify the auth_core + auth_idp clients build cleanly with `tsc`).
