### PR TITLE
v0.2.4: nullable model + exception ctor fields are omittable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.2.4
+
+- Ergonomics: nullable model and exception fields are now OMITTABLE on
+  the constructor's `init: {...}` bag. Callers can write
+  `new GetJoinedDivesRequest({ isCompleted: false, count: 10 })` instead
+  of having to pad every nullable field with `null`. Omitted fields
+  default to `null` at construction so the runtime field type stays
+  honest at `T | null`. Non-nullable fields stay required.
+  Endpoint named params already accepted omission for optional Dart
+  params (`?:` shape) — this only changes model + exception
+  constructors, where the previous required-property emission forced
+  callers to pass `null` repeatedly.
+
 ## 0.2.3
 
 - Bugfix: when generating a module client (`serverpod_auth_core`,

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -25,3 +25,4 @@ paths:
   - test/module_import_lines_test.dart
   - test/client_emitter_modules_test.dart
   - test/empty_barrel_emission_test.dart
+  - test/nullable_constructor_omission_test.dart

--- a/lib/src/emit/model_emitter.dart
+++ b/lib/src/emit/model_emitter.dart
@@ -296,18 +296,29 @@ class ModelEmitter {
       }
       w.blankLine();
 
+      // Nullable fields are emitted as optional properties on the
+      // constructor's init bag (`name?: T | null`) so callers don't
+      // have to pad with `null` for every nullable field. The body
+      // defaults omitted-or-undefined to `null` so the runtime field
+      // type stays honest at `T | null`. Non-nullable fields stay
+      // required — they have no meaningful default.
       w.writeln('constructor(init: {');
       w.indent(() {
         for (final field in fields) {
           final type = mapper.map(field.type);
-          w.writeln('${field.name}: ${type.tsType};');
+          final maybe = field.type.nullable ? '?' : '';
+          w.writeln('${field.name}$maybe: ${type.tsType};');
         }
       });
       w.writeln('}) {');
       w.indent(() {
         if (sealedAncestor != null) w.writeln('super();');
         for (final field in fields) {
-          w.writeln('this.${field.name} = init.${field.name};');
+          if (field.type.nullable) {
+            w.writeln('this.${field.name} = init.${field.name} ?? null;');
+          } else {
+            w.writeln('this.${field.name} = init.${field.name};');
+          }
         }
       });
       w.writeln('}');
@@ -419,11 +430,16 @@ class ModelEmitter {
       }
       w.blankLine();
 
+      // Same nullable-fields-are-optional treatment as `_emitClass`:
+      // callers can omit nullable fields and they default to `null`,
+      // so building an exception with only the message+a couple of
+      // populated fields stays one line.
       w.writeln('constructor(init: {');
       w.indent(() {
         for (final field in fields) {
           final type = mapper.map(field.type);
-          w.writeln('${field.name}: ${type.tsType};');
+          final maybe = field.type.nullable ? '?' : '';
+          w.writeln('${field.name}$maybe: ${type.tsType};');
         }
       });
       w.writeln('}) {');
@@ -436,7 +452,11 @@ class ModelEmitter {
         }
         w.writeln("this.name = '${model.className}';");
         for (final field in fields) {
-          w.writeln('this.${field.name} = init.${field.name};');
+          if (field.type.nullable) {
+            w.writeln('this.${field.name} = init.${field.name} ?? null;');
+          } else {
+            w.writeln('this.${field.name} = init.${field.name};');
+          }
         }
       });
       w.writeln('}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Generates a fully-typed TypeScript client for a Serverpod project, mirroring
   the behaviour of `serverpod generate` for Dart clients. Drop-in tooling for
   React/TypeScript SPAs powered by a Serverpod backend.
-version: 0.2.3
+version: 0.2.4
 repository: https://github.com/ChristopherLinnett/serverpod_typescript_bridge
 issue_tracker: https://github.com/ChristopherLinnett/serverpod_typescript_bridge/issues
 

--- a/test/nullable_constructor_omission_test.dart
+++ b/test/nullable_constructor_omission_test.dart
@@ -1,0 +1,186 @@
+// Regression coverage for the v0.2.4 ergonomics fix: nullable model
+// and exception fields should be OMITTABLE on the constructor's
+// `init: {...}` bag (callers can write `new Foo({ name: 'x' })`
+// instead of having to pad every nullable field with `null`).
+// Non-nullable fields stay required; the runtime field type stays
+// honest at `T | null` because the body defaults omitted to `null`.
+//
+// ignore_for_file: implementation_imports
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_typescript_bridge/src/discovery/module_class_index.dart';
+import 'package:serverpod_typescript_bridge/src/emit/generated_file_tracker.dart';
+import 'package:serverpod_typescript_bridge/src/emit/model_emitter.dart';
+import 'package:serverpod_typescript_bridge/src/emit/ts_type_mapper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory outputDir;
+
+  setUp(() {
+    outputDir = Directory.systemTemp.createTempSync('sptb_nullable_ctor_');
+  });
+
+  tearDown(() {
+    if (outputDir.existsSync()) outputDir.deleteSync(recursive: true);
+  });
+
+  GeneratedFileTracker freshTracker() {
+    return GeneratedFileTracker([
+      Directory(p.join(outputDir.path, 'src', 'protocol')),
+    ]);
+  }
+
+  TsTypeMapper bareMapper(Set<String> projectClassNames) {
+    return TsTypeMapper(
+      moduleIndex: ModuleClassIndex.empty,
+      projectClassNames: projectClassNames,
+    );
+  }
+
+  SerializableModelFieldDefinition field(
+    String name,
+    String className, {
+    bool nullable = false,
+  }) {
+    return SerializableModelFieldDefinition(
+      name: name,
+      type: TypeDefinition(className: className, nullable: nullable),
+      scope: ModelFieldScopeDefinition.all,
+      shouldPersist: false,
+    );
+  }
+
+  TypeDefinition selfType(String className) =>
+      TypeDefinition(className: className, nullable: false);
+
+  group('ModelEmitter — nullable fields in constructor init', () {
+    test(
+        'mixed nullable + non-nullable model: nullable becomes optional, '
+        'non-nullable stays required, body defaults nullable to null', () {
+      final model = ModelClassDefinition(
+        fileName: 'get_joined_dives_request',
+        sourceFileName: 'get_joined_dives_request.spy.yaml',
+        className: 'GetJoinedDivesRequest',
+        type: selfType('GetJoinedDivesRequest'),
+        serverOnly: false,
+        manageMigration: false,
+        isSealed: false,
+        isImmutable: false,
+        fields: [
+          field('isCompleted', 'bool'),
+          field('count', 'int'),
+          field('offset', 'int'),
+          field('startDate', 'DateTime', nullable: true),
+          field('endDate', 'DateTime', nullable: true),
+          field('diveType', 'String', nullable: true),
+        ],
+      );
+
+      ModelEmitter(
+        outputDir: outputDir,
+        tracker: freshTracker(),
+        mapper: bareMapper({'GetJoinedDivesRequest'}),
+      ).emitAll([model]);
+
+      final src = File(p.join(
+        outputDir.path,
+        'src',
+        'protocol',
+        'get_joined_dives_request.ts',
+      )).readAsStringSync();
+
+      // Required scalars stay `name: T;` in the init bag.
+      expect(src, contains('isCompleted: boolean;'));
+      expect(src, contains('count: number;'));
+      expect(src, contains('offset: number;'));
+      // Nullable scalars become `name?: T | null;` in the init bag.
+      expect(src, contains('startDate?: Date | null;'));
+      expect(src, contains('endDate?: Date | null;'));
+      expect(src, contains('diveType?: string | null;'));
+      // Constructor body: nullable fields default to null on omission.
+      expect(src, contains('this.startDate = init.startDate ?? null;'));
+      expect(src, contains('this.endDate = init.endDate ?? null;'));
+      expect(src, contains('this.diveType = init.diveType ?? null;'));
+      // Non-nullable assignments stay direct.
+      expect(src, contains('this.isCompleted = init.isCompleted;'));
+      expect(src, contains('this.count = init.count;'));
+      expect(src, isNot(contains('this.isCompleted = init.isCompleted ?? null')),
+          reason: 'non-nullable fields must not get the null fallback');
+    });
+
+    test(
+        'declared field types stay `T | null` post-construction so the runtime '
+        'shape matches the declared shape', () {
+      final model = ModelClassDefinition(
+        fileName: 'profile',
+        sourceFileName: 'profile.spy.yaml',
+        className: 'Profile',
+        type: selfType('Profile'),
+        serverOnly: false,
+        manageMigration: false,
+        isSealed: false,
+        isImmutable: false,
+        fields: [field('avatar', 'String', nullable: true)],
+      );
+
+      ModelEmitter(
+        outputDir: outputDir,
+        tracker: freshTracker(),
+        mapper: bareMapper({'Profile'}),
+      ).emitAll([model]);
+
+      final src = File(p.join(
+        outputDir.path, 'src', 'protocol', 'profile.ts',
+      )).readAsStringSync();
+
+      // The CLASS field declaration remains `T | null` (NOT `T | null | undefined`).
+      // Only the `init:` bag relaxes to optional.
+      expect(src, contains('avatar: string | null;'));
+      expect(src, contains('avatar?: string | null;'),
+          reason: 'init bag should make the nullable optional');
+    });
+  });
+
+  group('ModelEmitter — exception classes get the same treatment', () {
+    test(
+        'nullable exception fields are optional on init; required ones stay',
+        () {
+      final ex = ExceptionClassDefinition(
+        fileName: 'not_found_exception',
+        sourceFileName: 'not_found_exception.spy.yaml',
+        className: 'NotFoundException',
+        type: selfType('NotFoundException'),
+        serverOnly: false,
+        fields: [
+          field('message', 'String'),
+          field('resourceId', 'String', nullable: true),
+        ],
+      );
+
+      ModelEmitter(
+        outputDir: outputDir,
+        tracker: freshTracker(),
+        mapper: bareMapper({'NotFoundException'}),
+      ).emitAll([ex]);
+
+      final src = File(p.join(
+        outputDir.path,
+        'src',
+        'protocol',
+        'not_found_exception.ts',
+      )).readAsStringSync();
+
+      expect(src, contains('message: string;'),
+          reason: 'required field stays required in init bag');
+      expect(src, contains('resourceId?: string | null;'),
+          reason: 'nullable field becomes optional in init bag');
+      expect(src, contains('this.resourceId = init.resourceId ?? null;'),
+          reason: 'omitted nullable defaults to null at construction');
+      expect(src, contains('this.message = init.message;'),
+          reason: 'required field is assigned directly');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

v0.2.4 — ergonomic fix for model constructors.

You hit this in `freedive_finder_project`:

```ts
const dives = await client.dives.getJoinedDives(
  new GetJoinedDivesRequest({
    isCompleted: false,
    count: 10,
    offset: 0,
    endDate: null,        // ← had to spell these out
    startDate: null,      // ← every nullable field
    diveType: null,       // ← needed an explicit null
  }),
);
```

Cause: the model constructor's `init: {...}` bag declared every field as REQUIRED, even the nullable ones (`endDate: Date | null`). With v0.2.4 it becomes:

```ts
const dives = await client.dives.getJoinedDives(
  new GetJoinedDivesRequest({ isCompleted: false, count: 10, offset: 0 }),
);
```

## What changed

- `ModelEmitter._emitClass` and `_emitException` now emit nullable fields as `name?: T | null` in the `init: {...}` bag.
- Constructor body defaults omitted-or-undefined values to `null`: `this.field = init.field ?? null`.
- Field declarations on the class itself stay `name: T | null` (unchanged) — runtime type stays honest at `T | null`.
- Non-nullable fields stay required.
- `copyWith`, `fromJson`, `toJson`, the wire format, and the protocol switch are all unchanged. (toJson already stripped null fields from the wire envelope; omitted ctor fields produce the same wire shape as explicit `null`.)

## Endpoint params (no change)

Your example called the endpoint with a single positional `GetJoinedDivesRequest` arg — that's a model construction, not an endpoint param. Endpoint params already accept omission for all optional Dart shapes:
- Optional named (`{String? foo}`) → `foo?: string | null`
- Optional positional (`[String? foo]`) → `foo?: string | null`
- `required String? foo` (named) and required positional `String? foo` → `foo: string | null` (intentional — Dart marked these as required)

## Test plan

- [x] `dart analyze` clean.
- [x] `dart test` 109/109 passing (3 new unit tests asserting init shape, body fallback, and post-construction field-type invariant).
- [ ] Smoke against `freedive_finder_project` (verify the `new GetJoinedDivesRequest({...})` call you posted no longer needs the null padding).

Closes the ergonomics regression you reported on the v0.2.3 thread.
