### PR TITLE
docs: refresh README, architecture, runtime README, CONTRIBUTING for v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,25 @@ Generate a fully-typed TypeScript client for a Serverpod project — drop-in par
 
 ## Quick start
 
-```bash
-# inside your Serverpod server package
-dart pub add --dev serverpod_typescript_bridge
+The package isn't published to pub.dev yet — install via git ref. Add this to your Serverpod server package's `pubspec.yaml`:
 
-# generate the TS client (runs npm install + npm run build by default,
-# so the output is import-ready)
+```yaml
+dev_dependencies:
+  serverpod_typescript_bridge:
+    git:
+      url: https://github.com/ChristopherLinnett/serverpod_typescript_bridge.git
+      ref: v0.2.4   # or any later tag
+```
+
+Then:
+
+```bash
+cd path/to/your_app_server
+dart pub get
 dart run serverpod_typescript_bridge generate
 ```
 
-Pass `--no-build` if you want source files only (e.g. you're on
-pnpm/yarn/bun, or your CI runs the build step itself).
+`generate` runs `npm install` + `npm run build` for every module client (in dependency order) and then the app client, so the entire graph is import-ready when it exits. Pass `--no-build` to emit source only (e.g. on pnpm/yarn/bun, or in CI pipelines that drive the build step themselves).
 
 This writes a sibling package to your existing Dart client. If your server depends on Serverpod modules, each is generated as an additional sibling and the app client picks them up via `file:..` deps:
 
@@ -41,13 +49,27 @@ my_app/
 
 Pass `--no-gen-modules` to skip recursive module generation (e.g. when module clients are managed separately).
 
-Then in your TS/React app:
+In your TS/React app, install the generated package as a `file:` dep (one-time setup):
+
+```bash
+cd path/to/your_react_app
+npm install ../my_app_typescript_client
+```
+
+Then import and use it:
 
 ```ts
-import { Client } from 'my_app_typescript_client';
+import { Client, GetJoinedDivesRequest } from 'my_app_typescript_client';
 
 const client = new Client('https://api.my-app.com');
-const greeting = await client.greeting.sayHello('world');
+
+// Nullable model fields can be omitted (default to null at construction):
+const dives = await client.dives.getJoinedDives(
+  new GetJoinedDivesRequest({ isCompleted: false, count: 10, offset: 0 }),
+);
+
+// Cross-module types resolve through their generated package:
+import { AuthSuccess } from 'serverpod_auth_idp_typescript_client';
 ```
 
 ## Supported in v0.2
@@ -60,7 +82,7 @@ const greeting = await client.greeting.sayHello('world');
 | `@Deprecated` | ✅ | propagates to JSDoc `@deprecated` |
 | Primitives | ✅ | int, double, String, bool, DateTime, Duration, BigInt, UuidValue, ByteData |
 | Collections | ✅ | `List<T>`, `Set<T>`, `Map<String,V>`, `Map<K,V>` (non-string-keyed wire form) |
-| Nullables | ✅ | `T?` → `T \| null`; `copyWith` honours explicit `null` |
+| Nullables | ✅ | `T?` → `T \| null`; nullable fields are OMITTABLE on model/exception constructor `init` bags (default to `null`); `copyWith` honours explicit `null` vs "leave alone" |
 | Sealed hierarchies | ✅ | discriminated-union TS type + `<Name>Base.fromJson` dispatch on `__className__` |
 | Multi-level sealed | ✅ | every concrete subclass dispatches through every sealed ancestor |
 | Enums | ✅ | both `byIndex` and `byName` |
@@ -102,7 +124,9 @@ Options:
                     Override via `typescript_client_package_path` in
                     `config/generator.yaml`.
       --[no-]build         After emitting source, run `npm install` + `npm run build`
-                           in the output directory so it is import-ready (default: on).
+                           in every generated client (modules first, then the app)
+                           so the entire graph is import-ready (default: on). Build
+                           failures for a module are non-fatal and printed to stderr.
       --[no-]gen-modules   Recursively generate TS clients for every Serverpod
                            module the project depends on, as siblings of the app
                            client (default: on). The app client picks them up via


### PR DESCRIPTION
## Summary

Full audit pass on every doc in the repo to bring them current with v0.2.4. Doc-only, no code changes.

Two commits on this branch:

1. **`docs: refresh README for v0.2.4 state`** — top-level README updates.
2. **`docs: refresh architecture.md, runtime README, CONTRIBUTING for v0.2.4 state`** — the deeper docs.

## Files audited

| File | State found | Action |
|---|---|---|
| `README.md` | Install line claimed pub.dev (not published); module-build order undocumented; consumer-side `npm install` missing; v0.2.4 ergonomics not mentioned | Updated |
| `docs/architecture.md` | Significantly stale: claimed `protocol_emitter.dart` exists (it never did); missing 9 v0.2 files; CLI section showed never-shipped `--watch` and was missing every actual flag; "v0.2 will publish runtime to npm" never happened (v0.2 went module-aware instead); testing section claimed golden tests + live serverpod_test harness, neither exist; versioning table wrong | Significant rewrite |
| `lib/runtime/typescript/README.md` | Claimed streaming was "out of scope"; missing `ws_transport.ts` + `ws_messages.ts` from the module table; status still said "v0.2 will publish to npm" | Rewritten |
| `CONTRIBUTING.md` | Test counts stale (claimed 77+ Dart, actually 109; 60+ TS, actually 62); release step still said "deferred to v0.2" | Counts + wording fixed |
| `CHANGELOG.md` | Already current through v0.2.4 | No change |

## Notable changes in `architecture.md`

- New top-level shape diagram showing the v0.2 sibling-modules + `file:..` deps layout.
- New "Module discovery (v0.2)" section explaining `discovery/`, the `ModuleClassIndex.excluding(...)` per-run scoping, and the layout resolver.
- File inventory now matches reality across `lib/src/{emit,discovery,analyzer,cli}/`.
- "Runtime distribution" reframed: vendored is the v0.2 reality, not a transition. The originally-pencilled npm publish didn't ship; v0.2 went module-aware instead and the vendored approach composes cleanly with the new `file:..` wiring.
- Type mapping table updated with `void`, `dynamic`, `Object`, module-defined classes (cross-package), and the foreign-unknown fallback. Records dropped (post-v0.2).
- Models example shows the v0.2.4 omittable-nullable ctor shape.
- CLI reference: dropped `--watch`, added `--build`/`--no-build`/`--gen-modules`/`--no-gen-modules`/`--output`, plus `inspect` and the `typescript_client_modules:` override block.
- Dependency policy: added `serverpod_shared`, `meta`; clarified the analyzer dep.
- Testing strategy rewritten: 109 Dart cases + 62 vitest cases; no golden tests, no live serverpod_test harness — fixture-driven integration via the CLI subprocess + tsc.
- Versioning table updated with the actual v0.2.x theme (module-aware generation, not npm runtime publish).

## Test plan

- [x] Doc-only — no code changes.
- [x] All references cross-checked against current `lib/src/` and `lib/runtime/typescript/src/` file inventories.
- [x] CLI flag descriptions cross-checked against `lib/src/cli/generate_command.dart`.
- [x] Test counts confirmed against the latest local `dart test` + `npm test` runs.
